### PR TITLE
feat: scaffold agenthub service architecture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+PORT=3000
+LOG_LEVEL=debug
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agenthub
+REDIS_URL=redis://localhost:6379
+DEV_PUBLISHER_SUBJECT=publisher:local-dev
+CORS_ORIGIN=*

--- a/bun.lock
+++ b/bun.lock
@@ -5,15 +5,84 @@
     "": {
       "name": "agenthub",
       "dependencies": {
+        "@elysiajs/cors": "latest",
+        "@elysiajs/openapi": "latest",
+        "drizzle-orm": "latest",
         "elysia": "latest",
+        "pg": "latest",
       },
       "devDependencies": {
+        "@types/pg": "latest",
         "bun-types": "latest",
+        "drizzle-kit": "latest",
+        "typescript": "latest",
       },
     },
   },
   "packages": {
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
+    "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@elysiajs/cors": ["@elysiajs/cors@1.4.1", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-lQfad+F3r4mNwsxRKbXyJB8Jg43oAOXjRwn7sKUL6bcOW3KjUqUimTS+woNpO97efpzjtDE0tEjGk9DTw8lqTQ=="],
+
+    "@elysiajs/openapi": ["@elysiajs/openapi@1.4.14", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-kWmJWdvP8/LwHwAJXSpz6xFfYUoyUyEPRimEYABuDU1rOnS27Da1u9T2jyU7frOopxKWV/wDfDxMP8z2xdCPJw=="],
+
+    "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
+
+    "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
@@ -23,19 +92,33 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@types/pg": ["@types/pg@8.20.0", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow=="],
+
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
+
+    "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
+
     "elysia": ["elysia@1.4.28", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-Vrx8sBnvq8squS/3yNBzR1jBXI+SgmnmvwawPjNuEHndUe5l1jV2Gp6JJ4ulDkEB8On6bWmmuyPpA+bq4t+WYg=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
 
     "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
     "file-type": ["file-type@22.0.1", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0" } }, "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -45,12 +128,150 @@
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
+    "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.3.0", "", {}, "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ=="],
+
+    "pg-connection-string": ["pg-connection-string@2.12.0", "", {}, "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.13.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA=="],
+
+    "pg-protocol": ["pg-protocol@1.13.0", "", {}, "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
+
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
     "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
 
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
+
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
+    "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.18.20", "", { "os": "android", "cpu": "arm64" }, "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.18.20", "", { "os": "android", "cpu": "x64" }, "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.18.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.18.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.18.20", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.18.20", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.18.20", "", { "os": "linux", "cpu": "arm" }, "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.18.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.18.20", "", { "os": "linux", "cpu": "ia32" }, "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.18.20", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.18.20", "", { "os": "linux", "cpu": "s390x" }, "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.18.20", "", { "os": "linux", "cpu": "x64" }, "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.18.20", "", { "os": "none", "cpu": "x64" }, "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.18.20", "", { "os": "openbsd", "cpu": "x64" }, "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.18.20", "", { "os": "sunos", "cpu": "x64" }, "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.18.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
   }
 }

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./src/lib/db.ts",
+  out: "./migrations",
+  dialect: "postgresql",
+  dbCredentials: {
+    url: process.env.DATABASE_URL ?? "postgresql://postgres:postgres@localhost:5432/agenthub",
+  },
+  strict: true,
+  verbose: true,
+});

--- a/package.json
+++ b/package.json
@@ -2,14 +2,25 @@
   "name": "agenthub",
   "version": "1.0.50",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "bun run --watch src/index.ts"
+    "dev": "bun --watch run src/index.ts",
+    "start": "bun run src/index.ts",
+    "test": "bun test",
+    "test:watch": "bun test --watch",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate"
   },
   "dependencies": {
-    "elysia": "latest"
+    "@elysiajs/cors": "latest",
+    "@elysiajs/openapi": "latest",
+    "drizzle-orm": "latest",
+    "elysia": "latest",
+    "pg": "latest"
   },
   "devDependencies": {
-    "bun-types": "latest"
+    "@types/pg": "latest",
+    "bun-types": "latest",
+    "drizzle-kit": "latest",
+    "typescript": "latest"
   },
-  "module": "src/index.js"
+  "module": "src/index.ts"
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,91 @@
+import { Elysia } from "elysia";
+
+import { AppError } from "./common/errors/app-error";
+import { HttpError } from "./common/errors/http-error";
+import { errorEnvelopeSchema } from "./common/types/api";
+import { authPlugin } from "./plugins/auth";
+import { corsPlugin } from "./plugins/cors";
+import { docsPlugin } from "./plugins/docs";
+import { loggerPlugin } from "./plugins/logger";
+import { healthRoute } from "./modules/health/health.route";
+import { publicationPlugin } from "./modules/publication/publication.plugin";
+import { verificationPlugin } from "./modules/verification/verification.plugin";
+import { discoveryPlugin } from "./modules/discovery/discovery.plugin";
+
+const mapUnknownError = (error: unknown) => {
+  if (error instanceof AppError) {
+    return error;
+  }
+
+  return HttpError.internal(
+    "internal_server_error",
+    "The server encountered an unexpected error.",
+  );
+};
+
+const readValidationContext = (error: unknown) => {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+
+  const direct = error as {
+    on?: string;
+    property?: string;
+    message?: string;
+  };
+
+  if (direct.on || direct.property) {
+    return direct;
+  }
+
+  if (!direct.message) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(direct.message) as {
+      on?: string;
+      property?: string;
+    };
+
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+export const buildApp = () =>
+  new Elysia()
+    .model({
+      ErrorEnvelope: errorEnvelopeSchema,
+    })
+    .use(loggerPlugin)
+    .use(corsPlugin)
+    .use(docsPlugin)
+    .use(authPlugin)
+    .use(healthRoute)
+    .use(publicationPlugin)
+    .use(verificationPlugin)
+    .use(discoveryPlugin)
+    .onError(({ code, error, set }) => {
+      if (code === "VALIDATION") {
+        const validationErrorContext = readValidationContext(error);
+        const isAgentIdError =
+          validationErrorContext?.on === "params" &&
+          validationErrorContext?.property === "/agentId";
+        const validationError = HttpError.badRequest(
+          isAgentIdError ? "invalid_agent_id" : "invalid_request_body",
+          isAgentIdError
+            ? "The provided agent_id is invalid."
+            : "The request failed validation.",
+          { cause: error.message },
+        );
+
+        set.status = validationError.status;
+        return validationError.toResponse();
+      }
+
+      const appError = mapUnknownError(error);
+      set.status = appError.status;
+      return appError.toResponse();
+    });

--- a/src/common/errors/app-error.ts
+++ b/src/common/errors/app-error.ts
@@ -1,0 +1,36 @@
+import type { ErrorEnvelope } from "../types/api";
+
+export interface AppErrorOptions {
+  status: number;
+  code: string;
+  message: string;
+  retryable?: boolean;
+  details?: unknown;
+}
+
+export class AppError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly retryable: boolean;
+  readonly details?: unknown;
+
+  constructor(options: AppErrorOptions) {
+    super(options.message);
+    this.name = "AppError";
+    this.status = options.status;
+    this.code = options.code;
+    this.retryable = options.retryable ?? false;
+    this.details = options.details;
+  }
+
+  toResponse(): ErrorEnvelope {
+    return {
+      error: {
+        code: this.code,
+        message: this.message,
+        retryable: this.retryable,
+        details: this.details,
+      },
+    };
+  }
+}

--- a/src/common/errors/http-error.ts
+++ b/src/common/errors/http-error.ts
@@ -1,0 +1,53 @@
+import { AppError } from "./app-error";
+
+export class HttpError extends AppError {
+  static badRequest(code: string, message: string, details?: unknown): HttpError {
+    return new HttpError({ status: 400, code, message, details });
+  }
+
+  static unauthorized(
+    code: string,
+    message: string,
+    details?: unknown,
+  ): HttpError {
+    return new HttpError({ status: 401, code, message, details });
+  }
+
+  static forbidden(code: string, message: string, details?: unknown): HttpError {
+    return new HttpError({ status: 403, code, message, details });
+  }
+
+  static notFound(code: string, message: string, details?: unknown): HttpError {
+    return new HttpError({ status: 404, code, message, details });
+  }
+
+  static conflict(code: string, message: string, details?: unknown): HttpError {
+    return new HttpError({ status: 409, code, message, details });
+  }
+
+  static unprocessable(
+    code: string,
+    message: string,
+    details?: unknown,
+  ): HttpError {
+    return new HttpError({ status: 422, code, message, details });
+  }
+
+  static notImplemented(
+    code: string,
+    message: string,
+    details?: unknown,
+  ): HttpError {
+    return new HttpError({ status: 501, code, message, details });
+  }
+
+  static internal(code: string, message: string, details?: unknown): HttpError {
+    return new HttpError({
+      status: 500,
+      code,
+      message,
+      details,
+      retryable: true,
+    });
+  }
+}

--- a/src/common/types/api.ts
+++ b/src/common/types/api.ts
@@ -1,0 +1,226 @@
+import { t } from "elysia";
+
+import {
+  AGENT_ID_PATTERN,
+  APP_NAME,
+  APP_VERSION,
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+} from "../../config/constants";
+
+export interface PublisherContext {
+  subject: string;
+  isAuthenticated: boolean;
+}
+
+export const appErrorSchema = t.Object({
+  code: t.String(),
+  message: t.String(),
+  retryable: t.Boolean(),
+  details: t.Optional(t.Unknown()),
+});
+
+export const errorEnvelopeSchema = t.Object({
+  error: appErrorSchema,
+});
+
+export const healthResponseSchema = t.Object({
+  status: t.Literal("ok"),
+  service: t.String({ default: APP_NAME }),
+  version: t.String({ default: APP_VERSION }),
+  timestamp: t.String({ format: "date-time" }),
+});
+
+export const visibilitySchema = t.Union([
+  t.Literal("public"),
+  t.Literal("restricted"),
+]);
+
+export const accessModeSchema = t.Union([
+  t.Literal("public"),
+  t.Literal("protected"),
+]);
+
+export const publicationStatusSchema = t.Union([
+  t.Literal("pending_verification"),
+  t.Literal("active"),
+  t.Literal("inactive"),
+  t.Literal("invalid"),
+]);
+
+export const factsRefSchema = t.Object(
+  {
+    type: t.Union([t.Literal("public_url"), t.Literal("brokered_url")]),
+    url: t.String({ format: "uri" }),
+  },
+  { additionalProperties: false },
+);
+
+export const summaryOverridesSchema = t.Object(
+  {
+    provider: t.Optional(t.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const agentPublicationSchema = t.Object(
+  {
+    agent_card_url: t.String({
+      format: "uri",
+      pattern: "^https://",
+    }),
+    visibility: visibilitySchema,
+    facts_ref: t.Optional(t.Union([factsRefSchema, t.Null()])),
+    summary_overrides: t.Optional(summaryOverridesSchema),
+  },
+  { additionalProperties: false },
+);
+
+export const agentCardRefSchema = t.Object(
+  {
+    source_url: t.String({ format: "uri" }),
+    access_url: t.String({ format: "uri" }),
+    access_mode: accessModeSchema,
+    last_validated_at: t.String({ format: "date-time" }),
+    etag: t.Optional(t.String()),
+  },
+  { additionalProperties: false },
+);
+
+export const domainVerificationChallengeSchema = t.Object(
+  {
+    method: t.Literal("well_known_token"),
+    url: t.String({ format: "uri" }),
+    token: t.String(),
+    expires_at: t.String({ format: "date-time" }),
+  },
+  { additionalProperties: false },
+);
+
+export const agentIndexRecordSchema = t.Object(
+  {
+    agent_id: t.String({ pattern: AGENT_ID_PATTERN }),
+    display_name: t.String(),
+    provider: t.Optional(t.String()),
+    agent_card_ref: agentCardRefSchema,
+    skills: t.Array(t.String()),
+    tags: t.Array(t.String()),
+    supported_bindings: t.Array(t.String()),
+    visibility: visibilitySchema,
+    ttl_seconds: t.Number(),
+    updated_at: t.String({ format: "date-time" }),
+    status: publicationStatusSchema,
+    facts_ref: t.Optional(t.Union([factsRefSchema, t.Null()])),
+  },
+  { additionalProperties: false },
+);
+
+export const publisherAgentRecordSchema = t.Object(
+  {
+    agent_id: t.String({ pattern: AGENT_ID_PATTERN }),
+    publication: agentPublicationSchema,
+    status: publicationStatusSchema,
+    agent_card_ref: agentCardRefSchema,
+    ownership: t.Object(
+      {
+        namespace: t.String(),
+        owner_subject: t.String(),
+      },
+      { additionalProperties: false },
+    ),
+    challenge: t.Optional(domainVerificationChallengeSchema),
+    last_validated_at: t.String({ format: "date-time" }),
+    verified_at: t.Optional(t.Union([t.String({ format: "date-time" }), t.Null()])),
+    last_error: t.Optional(t.Union([t.String(), t.Null()])),
+  },
+  { additionalProperties: false },
+);
+
+export const agentIdParamsSchema = t.Object({
+  agentId: t.String({ pattern: AGENT_ID_PATTERN }),
+});
+
+export const verifyDomainRequestSchema = t.Object(
+  {
+    method: t.Literal("well_known_token"),
+  },
+  { additionalProperties: false },
+);
+
+export const publishAcceptedResponseSchema = t.Object(
+  {
+    agent_id: t.String({ pattern: AGENT_ID_PATTERN }),
+    status: publicationStatusSchema,
+    challenge: t.Optional(domainVerificationChallengeSchema),
+  },
+  { additionalProperties: false },
+);
+
+export const deactivateResponseSchema = t.Object(
+  {
+    agent_id: t.String({ pattern: AGENT_ID_PATTERN }),
+    status: t.Literal("inactive"),
+  },
+  { additionalProperties: false },
+);
+
+export const verifyDomainResponseSchema = t.Object(
+  {
+    agent_id: t.String({ pattern: AGENT_ID_PATTERN }),
+    status: t.Literal("active"),
+    verified_at: t.String({ format: "date-time" }),
+  },
+  { additionalProperties: false },
+);
+
+export const searchQuerySchema = t.Object(
+  {
+    text: t.Optional(t.String()),
+    skills: t.Optional(t.Array(t.String())),
+    tags: t.Optional(t.Array(t.String())),
+    provider: t.Optional(t.String()),
+    visibility: t.Optional(visibilitySchema),
+    supported_bindings: t.Optional(t.Array(t.String())),
+    page_size: t.Optional(
+      t.Numeric({
+        minimum: 1,
+        maximum: MAX_PAGE_SIZE,
+        default: DEFAULT_PAGE_SIZE,
+      }),
+    ),
+    page_token: t.Optional(t.Union([t.String(), t.Null()])),
+  },
+  { additionalProperties: false },
+);
+
+export const searchEnvelopeSchema = t.Object(
+  {
+    query: searchQuerySchema,
+  },
+  { additionalProperties: false },
+);
+
+export const searchResponseSchema = t.Object(
+  {
+    results: t.Array(agentIndexRecordSchema),
+    next_page_token: t.Union([t.String(), t.Null()]),
+  },
+  { additionalProperties: false },
+);
+
+export type AppErrorPayload = typeof appErrorSchema.static;
+export type ErrorEnvelope = typeof errorEnvelopeSchema.static;
+export type HealthResponse = typeof healthResponseSchema.static;
+export type AgentPublication = typeof agentPublicationSchema.static;
+export type AgentCardRef = typeof agentCardRefSchema.static;
+export type DomainVerificationChallenge =
+  typeof domainVerificationChallengeSchema.static;
+export type AgentIndexRecord = typeof agentIndexRecordSchema.static;
+export type PublisherAgentRecord = typeof publisherAgentRecordSchema.static;
+export type PublicationStatus = typeof publicationStatusSchema.static;
+export type PublishAcceptedResponse = typeof publishAcceptedResponseSchema.static;
+export type DeactivateResponse = typeof deactivateResponseSchema.static;
+export type VerifyDomainRequest = typeof verifyDomainRequestSchema.static;
+export type VerifyDomainResponse = typeof verifyDomainResponseSchema.static;
+export type SearchEnvelope = typeof searchEnvelopeSchema.static;
+export type SearchResponse = typeof searchResponseSchema.static;

--- a/src/common/utils/crypto.ts
+++ b/src/common/utils/crypto.ts
@@ -1,0 +1,2 @@
+export const generateOpaqueToken = (prefix = "ahv1"): string =>
+  `${prefix}_${crypto.randomUUID().replaceAll("-", "")}`;

--- a/src/common/utils/time.ts
+++ b/src/common/utils/time.ts
@@ -1,0 +1,4 @@
+export const nowIso = (): string => new Date().toISOString();
+
+export const addMinutes = (input: Date, minutes: number): string =>
+  new Date(input.getTime() + minutes * 60_000).toISOString();

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,0 +1,13 @@
+export const APP_NAME = "AgentHub";
+export const API_VERSION = "v1";
+export const APP_VERSION = "0.1.0";
+export const DEFAULT_PORT = 3000;
+export const DOCS_PATH = "/docs";
+export const DOCS_JSON_PATH = "/docs/openapi.json";
+export const HEALTH_PATH = "/health";
+export const DEFAULT_LOG_LEVEL = "debug";
+export const DEFAULT_DEV_PUBLISHER_SUBJECT = "publisher:local-dev";
+export const DEFAULT_PAGE_SIZE = 10;
+export const MAX_PAGE_SIZE = 100;
+export const AGENT_ID_PATTERN =
+  "^[a-z0-9]+(?:-[a-z0-9]+)*(?:\\.[a-z0-9]+(?:-[a-z0-9]+)*)+$";

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,45 @@
+import {
+  DEFAULT_DEV_PUBLISHER_SUBJECT,
+  DEFAULT_LOG_LEVEL,
+  DEFAULT_PORT,
+} from "./constants";
+
+export type NodeEnv = "development" | "test" | "production";
+
+export interface AppEnv {
+  NODE_ENV: NodeEnv;
+  PORT: number;
+  LOG_LEVEL: string;
+  DATABASE_URL?: string;
+  REDIS_URL?: string;
+  DEV_PUBLISHER_SUBJECT: string;
+  CORS_ORIGIN: string;
+}
+
+const parsePort = (value: string | undefined): number => {
+  if (!value) {
+    return DEFAULT_PORT;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_PORT;
+};
+
+const parseNodeEnv = (value: string | undefined): NodeEnv => {
+  if (value === "production" || value === "test") {
+    return value;
+  }
+
+  return "development";
+};
+
+export const env: AppEnv = {
+  NODE_ENV: parseNodeEnv(process.env.NODE_ENV),
+  PORT: parsePort(process.env.PORT),
+  LOG_LEVEL: process.env.LOG_LEVEL ?? DEFAULT_LOG_LEVEL,
+  DATABASE_URL: process.env.DATABASE_URL,
+  REDIS_URL: process.env.REDIS_URL,
+  DEV_PUBLISHER_SUBJECT:
+    process.env.DEV_PUBLISHER_SUBJECT ?? DEFAULT_DEV_PUBLISHER_SUBJECT,
+  CORS_ORIGIN: process.env.CORS_ORIGIN ?? "*",
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
-import { Elysia } from "elysia";
+import { env } from "./config/env";
+import { buildApp } from "./app";
 
-const app = new Elysia().get("/", () => "Hello Elysia").listen(3000);
+const app = buildApp();
 
-console.log(
-  `🦊 Elysia is running at ${app.server?.hostname}:${app.server?.port}`
-);
+app.listen(env.PORT);
+
+console.log(`AgentHub listening on http://localhost:${env.PORT}`);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,139 @@
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/node-postgres";
+import {
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { Pool } from "pg";
+
+import { env } from "../config/env";
+
+export const visibilityEnum = pgEnum("agent_visibility", [
+  "public",
+  "restricted",
+]);
+export const accessModeEnum = pgEnum("agent_access_mode", [
+  "public",
+  "protected",
+]);
+export const publicationStatusEnum = pgEnum("publication_status", [
+  "pending_verification",
+  "active",
+  "inactive",
+  "invalid",
+]);
+export const verificationMethodEnum = pgEnum("verification_method", [
+  "well_known_token",
+]);
+export const factsRefTypeEnum = pgEnum("facts_ref_type", [
+  "public_url",
+  "brokered_url",
+]);
+
+export const namespacesTable = pgTable("namespaces", {
+  namespace: text("namespace").primaryKey(),
+  ownerSubject: text("owner_subject").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const publicationsTable = pgTable(
+  "agent_publications",
+  {
+    agentId: text("agent_id").primaryKey(),
+    namespace: text("namespace")
+      .notNull()
+      .references(() => namespacesTable.namespace),
+    sourceUrl: text("source_url").notNull(),
+    accessUrl: text("access_url").notNull(),
+    accessMode: accessModeEnum("access_mode").notNull(),
+    visibility: visibilityEnum("visibility").notNull(),
+    status: publicationStatusEnum("status").notNull(),
+    factsRefType: factsRefTypeEnum("facts_ref_type"),
+    factsRefUrl: text("facts_ref_url"),
+    summaryProvider: text("summary_provider"),
+    lastValidatedAt: timestamp("last_validated_at", { withTimezone: true }),
+    verifiedAt: timestamp("verified_at", { withTimezone: true }),
+    lastError: text("last_error"),
+    etag: text("etag"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    sourceUrlIdx: uniqueIndex("agent_publications_source_url_idx").on(table.sourceUrl),
+  }),
+);
+
+export const snapshotsTable = pgTable("agent_snapshots", {
+  agentId: text("agent_id")
+    .primaryKey()
+    .references(() => publicationsTable.agentId),
+  displayName: text("display_name").notNull(),
+  provider: text("provider"),
+  skills: jsonb("skills").$type<string[]>().notNull().default(sql`'[]'::jsonb`),
+  tags: jsonb("tags").$type<string[]>().notNull().default(sql`'[]'::jsonb`),
+  supportedBindings: jsonb("supported_bindings")
+    .$type<string[]>()
+    .notNull()
+    .default(sql`'[]'::jsonb`),
+  ttlSeconds: integer("ttl_seconds").notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const verificationChallengesTable = pgTable(
+  "verification_challenges",
+  {
+    agentId: text("agent_id")
+      .primaryKey()
+      .references(() => publicationsTable.agentId),
+    method: verificationMethodEnum("method").notNull(),
+    url: text("url").notNull(),
+    token: text("token").notNull(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    refreshedAt: timestamp("refreshed_at", { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    tokenIdx: uniqueIndex("verification_challenges_token_idx").on(table.token),
+  }),
+);
+
+export const schema = {
+  namespacesTable,
+  publicationsTable,
+  snapshotsTable,
+  verificationChallengesTable,
+};
+
+let pool: Pool | null = null;
+let database: ReturnType<typeof drizzle<typeof schema>> | null = null;
+
+export const getDb = () => {
+  if (!env.DATABASE_URL) {
+    return null;
+  }
+
+  if (!pool) {
+    pool = new Pool({ connectionString: env.DATABASE_URL });
+  }
+
+  if (!database) {
+    database = drizzle({ client: pool, schema });
+  }
+
+  return database;
+};
+
+export const closeDb = async () => {
+  if (pool) {
+    await pool.end();
+  }
+
+  pool = null;
+  database = null;
+};

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,0 +1,33 @@
+import { env } from "../config/env";
+
+export interface RedisClient {
+  readonly isConfigured: boolean;
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ttlSeconds?: number): Promise<void>;
+  del(key: string): Promise<void>;
+  ping(): Promise<string>;
+}
+
+class NoopRedisClient implements RedisClient {
+  readonly isConfigured: boolean;
+
+  constructor(isConfigured: boolean) {
+    this.isConfigured = isConfigured;
+  }
+
+  async get(_key: string): Promise<string | null> {
+    return null;
+  }
+
+  async set(_key: string, _value: string, _ttlSeconds?: number): Promise<void> {}
+
+  async del(_key: string): Promise<void> {}
+
+  async ping(): Promise<string> {
+    return this.isConfigured ? "deferred" : "disabled";
+  }
+}
+
+const redisClient = new NoopRedisClient(Boolean(env.REDIS_URL));
+
+export const getRedisClient = (): RedisClient => redisClient;

--- a/src/modules/discovery/discovery.model.ts
+++ b/src/modules/discovery/discovery.model.ts
@@ -1,0 +1,13 @@
+import {
+  agentIdParamsSchema,
+  agentIndexRecordSchema,
+  errorEnvelopeSchema,
+  searchEnvelopeSchema,
+  searchResponseSchema,
+} from "../../common/types/api";
+
+export const discoveryParamsSchema = agentIdParamsSchema;
+export const getAgentResponseSchema = agentIndexRecordSchema;
+export const searchAgentsBodySchema = searchEnvelopeSchema;
+export const searchAgentsResponseSchema = searchResponseSchema;
+export const discoveryErrorResponseSchema = errorEnvelopeSchema;

--- a/src/modules/discovery/discovery.plugin.ts
+++ b/src/modules/discovery/discovery.plugin.ts
@@ -1,0 +1,13 @@
+import { Elysia } from "elysia";
+
+import { createDiscoveryRoutes } from "./discovery.route";
+import { DrizzleDiscoveryRepository } from "./discovery.repo";
+import { DiscoveryService } from "./discovery.service";
+
+const discoveryRepo = new DrizzleDiscoveryRepository();
+const discoveryService = new DiscoveryService(discoveryRepo);
+
+export const discoveryPlugin = new Elysia({
+  name: "discovery-plugin",
+  prefix: "/v1/agents",
+}).use(createDiscoveryRoutes(discoveryService));

--- a/src/modules/discovery/discovery.repo.ts
+++ b/src/modules/discovery/discovery.repo.ts
@@ -1,0 +1,28 @@
+import { getDb } from "../../lib/db";
+import type {
+  AgentIndexRecord,
+  SearchEnvelope,
+  SearchResponse,
+} from "../../common/types/api";
+
+export interface DiscoveryRepository {
+  getByAgentId(agentId: string): Promise<AgentIndexRecord | null>;
+  search(query: SearchEnvelope): Promise<SearchResponse>;
+}
+
+export class DrizzleDiscoveryRepository implements DiscoveryRepository {
+  async getByAgentId(_agentId: string): Promise<AgentIndexRecord | null> {
+    const db = getDb();
+    void db;
+    return null;
+  }
+
+  async search(_query: SearchEnvelope): Promise<SearchResponse> {
+    const db = getDb();
+    void db;
+    return {
+      results: [],
+      next_page_token: null,
+    };
+  }
+}

--- a/src/modules/discovery/discovery.route.ts
+++ b/src/modules/discovery/discovery.route.ts
@@ -1,0 +1,48 @@
+import { Elysia } from "elysia";
+
+import { DiscoveryService } from "./discovery.service";
+import {
+  discoveryErrorResponseSchema,
+  discoveryParamsSchema,
+  getAgentResponseSchema,
+  searchAgentsBodySchema,
+  searchAgentsResponseSchema,
+} from "./discovery.model";
+
+export const createDiscoveryRoutes = (service: DiscoveryService) =>
+  new Elysia({ name: "discovery-routes" })
+    .get(
+      "/:agentId",
+      async ({ params }) => service.getAgentById(params.agentId),
+      {
+        params: discoveryParamsSchema,
+        response: {
+          200: getAgentResponseSchema,
+          400: discoveryErrorResponseSchema,
+          403: discoveryErrorResponseSchema,
+          404: discoveryErrorResponseSchema,
+          501: discoveryErrorResponseSchema,
+        },
+        detail: {
+          summary: "Lookup a discoverable agent by id",
+          tags: ["Discovery"],
+        },
+      },
+    )
+    .post(
+      "/search",
+      async ({ body }) => service.searchAgents(body),
+      {
+        body: searchAgentsBodySchema,
+        response: {
+          200: searchAgentsResponseSchema,
+          400: discoveryErrorResponseSchema,
+          401: discoveryErrorResponseSchema,
+          501: discoveryErrorResponseSchema,
+        },
+        detail: {
+          summary: "Search discoverable agents",
+          tags: ["Discovery"],
+        },
+      },
+    );

--- a/src/modules/discovery/discovery.service.ts
+++ b/src/modules/discovery/discovery.service.ts
@@ -1,0 +1,27 @@
+import { HttpError } from "../../common/errors/http-error";
+import type { AgentIndexRecord, SearchEnvelope, SearchResponse } from "../../common/types/api";
+import type { DiscoveryRepository } from "./discovery.repo";
+
+export class DiscoveryService {
+  constructor(private readonly discoveryRepo: DiscoveryRepository) {}
+
+  async getAgentById(agentId: string): Promise<AgentIndexRecord> {
+    void this.discoveryRepo;
+    void agentId;
+
+    throw HttpError.notImplemented(
+      "discovery_lookup_not_implemented",
+      "Exact agent lookup has not been implemented yet.",
+    );
+  }
+
+  async searchAgents(query: SearchEnvelope): Promise<SearchResponse> {
+    void this.discoveryRepo;
+    void query;
+
+    throw HttpError.notImplemented(
+      "discovery_search_not_implemented",
+      "Agent search has not been implemented yet.",
+    );
+  }
+}

--- a/src/modules/health/health.route.ts
+++ b/src/modules/health/health.route.ts
@@ -1,0 +1,24 @@
+import { Elysia } from "elysia";
+
+import { APP_NAME, APP_VERSION, HEALTH_PATH } from "../../config/constants";
+import { nowIso } from "../../common/utils/time";
+import { healthResponseSchema } from "../../common/types/api";
+
+export const healthRoute = new Elysia({ name: "health-route" }).get(
+  HEALTH_PATH,
+  () => ({
+    status: "ok" as const,
+    service: APP_NAME,
+    version: APP_VERSION,
+    timestamp: nowIso(),
+  }),
+  {
+    response: {
+      200: healthResponseSchema,
+    },
+    detail: {
+      summary: "Service health",
+      tags: ["Health"],
+    },
+  },
+);

--- a/src/modules/publication/publication.entity.ts
+++ b/src/modules/publication/publication.entity.ts
@@ -1,0 +1,14 @@
+import type {
+  AgentPublication,
+  PublicationStatus,
+  PublisherAgentRecord,
+} from "../../common/types/api";
+
+export interface PublicationEntity {
+  agentId: string;
+  namespace: string;
+  publication: AgentPublication;
+  status: PublicationStatus;
+}
+
+export type PublicationAdminView = PublisherAgentRecord;

--- a/src/modules/publication/publication.model.ts
+++ b/src/modules/publication/publication.model.ts
@@ -1,0 +1,15 @@
+import {
+  agentIdParamsSchema,
+  agentPublicationSchema,
+  deactivateResponseSchema,
+  errorEnvelopeSchema,
+  publishAcceptedResponseSchema,
+  publisherAgentRecordSchema,
+} from "../../common/types/api";
+
+export const publishAgentParamsSchema = agentIdParamsSchema;
+export const publishAgentBodySchema = agentPublicationSchema;
+export const publishAgentResponseSchema = publishAcceptedResponseSchema;
+export const getPublicationResponseSchema = publisherAgentRecordSchema;
+export const deactivateAgentResponseSchema = deactivateResponseSchema;
+export const publicationErrorResponseSchema = errorEnvelopeSchema;

--- a/src/modules/publication/publication.plugin.ts
+++ b/src/modules/publication/publication.plugin.ts
@@ -1,0 +1,13 @@
+import { Elysia } from "elysia";
+
+import { createPublicationRoutes } from "./publication.route";
+import { DrizzlePublicationRepository } from "./publication.repo";
+import { PublicationService } from "./publication.service";
+
+const publicationRepo = new DrizzlePublicationRepository();
+const publicationService = new PublicationService(publicationRepo);
+
+export const publicationPlugin = new Elysia({
+  name: "publication-plugin",
+  prefix: "/v1/publish/agents",
+}).use(createPublicationRoutes(publicationService));

--- a/src/modules/publication/publication.repo.ts
+++ b/src/modules/publication/publication.repo.ts
@@ -1,0 +1,41 @@
+import { getDb } from "../../lib/db";
+import type {
+  AgentPublication,
+  PublisherAgentRecord,
+  PublisherContext,
+} from "../../common/types/api";
+
+export interface PublicationRepository {
+  getByAgentId(agentId: string): Promise<PublisherAgentRecord | null>;
+  upsert(
+    agentId: string,
+    publication: AgentPublication,
+    publisher: PublisherContext,
+  ): Promise<void>;
+  deactivate(agentId: string, publisher: PublisherContext): Promise<void>;
+}
+
+export class DrizzlePublicationRepository implements PublicationRepository {
+  async getByAgentId(_agentId: string): Promise<PublisherAgentRecord | null> {
+    const db = getDb();
+    void db;
+    return null;
+  }
+
+  async upsert(
+    _agentId: string,
+    _publication: AgentPublication,
+    _publisher: PublisherContext,
+  ): Promise<void> {
+    const db = getDb();
+    void db;
+  }
+
+  async deactivate(
+    _agentId: string,
+    _publisher: PublisherContext,
+  ): Promise<void> {
+    const db = getDb();
+    void db;
+  }
+}

--- a/src/modules/publication/publication.route.ts
+++ b/src/modules/publication/publication.route.ts
@@ -1,0 +1,88 @@
+import { Elysia } from "elysia";
+
+import { buildPublisherContext } from "../../plugins/auth";
+import { PublicationService } from "./publication.service";
+import {
+  deactivateAgentResponseSchema,
+  getPublicationResponseSchema,
+  publicationErrorResponseSchema,
+  publishAgentBodySchema,
+  publishAgentParamsSchema,
+  publishAgentResponseSchema,
+} from "./publication.model";
+
+const publicationResponseSchemas = {
+  200: publishAgentResponseSchema,
+  201: publishAgentResponseSchema,
+  400: publicationErrorResponseSchema,
+  401: publicationErrorResponseSchema,
+  403: publicationErrorResponseSchema,
+  404: publicationErrorResponseSchema,
+  409: publicationErrorResponseSchema,
+  422: publicationErrorResponseSchema,
+  501: publicationErrorResponseSchema,
+};
+
+export const createPublicationRoutes = (service: PublicationService) =>
+  new Elysia({ name: "publication-routes" })
+    .put(
+      "/:agentId",
+      async ({ params, body, request }) =>
+        service.publishAgent(
+          params.agentId,
+          body,
+          buildPublisherContext(request),
+        ),
+      {
+        params: publishAgentParamsSchema,
+        body: publishAgentBodySchema,
+        response: publicationResponseSchemas,
+        detail: {
+          summary: "Publish or update an agent",
+          tags: ["Publication"],
+        },
+      },
+    )
+    .get(
+      "/:agentId",
+      async ({ params, request }) =>
+        service.getPublication(params.agentId, buildPublisherContext(request)),
+      {
+        params: publishAgentParamsSchema,
+        response: {
+          200: getPublicationResponseSchema,
+          400: publicationErrorResponseSchema,
+          401: publicationErrorResponseSchema,
+          403: publicationErrorResponseSchema,
+          404: publicationErrorResponseSchema,
+          501: publicationErrorResponseSchema,
+        },
+        detail: {
+          summary: "Retrieve owner-only publication state",
+          tags: ["Publication"],
+        },
+      },
+    )
+    .post(
+      "/:agentId/deactivate",
+      async ({ params, request }) =>
+        service.deactivateAgent(
+          params.agentId,
+          buildPublisherContext(request),
+        ),
+      {
+        params: publishAgentParamsSchema,
+        response: {
+          200: deactivateAgentResponseSchema,
+          400: publicationErrorResponseSchema,
+          401: publicationErrorResponseSchema,
+          403: publicationErrorResponseSchema,
+          404: publicationErrorResponseSchema,
+          501: publicationErrorResponseSchema,
+        },
+        detail: {
+          summary: "Deactivate a published agent",
+          tags: ["Publication"],
+        },
+      },
+    );

--- a/src/modules/publication/publication.service.ts
+++ b/src/modules/publication/publication.service.ts
@@ -1,0 +1,55 @@
+import { HttpError } from "../../common/errors/http-error";
+import type {
+  AgentPublication,
+  PublisherContext,
+  PublisherAgentRecord,
+} from "../../common/types/api";
+import type { PublicationRepository } from "./publication.repo";
+
+export class PublicationService {
+  constructor(private readonly publicationRepo: PublicationRepository) {}
+
+  async publishAgent(
+    agentId: string,
+    publication: AgentPublication,
+    publisher: PublisherContext,
+  ): Promise<never> {
+    void this.publicationRepo;
+    void agentId;
+    void publication;
+    void publisher;
+
+    throw HttpError.notImplemented(
+      "publication_publish_not_implemented",
+      "Publishing agents has not been implemented yet.",
+    );
+  }
+
+  async getPublication(
+    agentId: string,
+    publisher: PublisherContext,
+  ): Promise<never> {
+    void this.publicationRepo;
+    void agentId;
+    void publisher;
+
+    throw HttpError.notImplemented(
+      "publication_get_not_implemented",
+      "Publication administration retrieval has not been implemented yet.",
+    );
+  }
+
+  async deactivateAgent(
+    agentId: string,
+    publisher: PublisherContext,
+  ): Promise<never> {
+    void this.publicationRepo;
+    void agentId;
+    void publisher;
+
+    throw HttpError.notImplemented(
+      "publication_deactivate_not_implemented",
+      "Deactivating agents has not been implemented yet.",
+    );
+  }
+}

--- a/src/modules/verification/verification.model.ts
+++ b/src/modules/verification/verification.model.ts
@@ -1,0 +1,11 @@
+import {
+  agentIdParamsSchema,
+  errorEnvelopeSchema,
+  verifyDomainRequestSchema,
+  verifyDomainResponseSchema,
+} from "../../common/types/api";
+
+export const verifyDomainParamsSchema = agentIdParamsSchema;
+export const verifyDomainBodySchema = verifyDomainRequestSchema;
+export const verifyDomainSuccessSchema = verifyDomainResponseSchema;
+export const verificationErrorResponseSchema = errorEnvelopeSchema;

--- a/src/modules/verification/verification.plugin.ts
+++ b/src/modules/verification/verification.plugin.ts
@@ -1,0 +1,11 @@
+import { Elysia } from "elysia";
+
+import { createVerificationRoutes } from "./verification.route";
+import { VerificationService } from "./verification.service";
+
+const verificationService = new VerificationService();
+
+export const verificationPlugin = new Elysia({
+  name: "verification-plugin",
+  prefix: "/v1/publish/agents",
+}).use(createVerificationRoutes(verificationService));

--- a/src/modules/verification/verification.route.ts
+++ b/src/modules/verification/verification.route.ts
@@ -1,0 +1,38 @@
+import { Elysia } from "elysia";
+
+import { buildPublisherContext } from "../../plugins/auth";
+import { VerificationService } from "./verification.service";
+import {
+  verificationErrorResponseSchema,
+  verifyDomainBodySchema,
+  verifyDomainParamsSchema,
+  verifyDomainSuccessSchema,
+} from "./verification.model";
+
+export const createVerificationRoutes = (service: VerificationService) =>
+  new Elysia({ name: "verification-routes" }).post(
+    "/:agentId/verify-domain",
+    async ({ params, body, request }) =>
+      service.verifyDomain(
+        params.agentId,
+        body,
+        buildPublisherContext(request),
+      ),
+    {
+      params: verifyDomainParamsSchema,
+      body: verifyDomainBodySchema,
+      response: {
+        200: verifyDomainSuccessSchema,
+        400: verificationErrorResponseSchema,
+        401: verificationErrorResponseSchema,
+        403: verificationErrorResponseSchema,
+        404: verificationErrorResponseSchema,
+        409: verificationErrorResponseSchema,
+        501: verificationErrorResponseSchema,
+      },
+      detail: {
+        summary: "Verify domain ownership for a pending publication",
+        tags: ["Verification"],
+      },
+    },
+  );

--- a/src/modules/verification/verification.service.ts
+++ b/src/modules/verification/verification.service.ts
@@ -1,0 +1,22 @@
+import { HttpError } from "../../common/errors/http-error";
+import type {
+  PublisherContext,
+  VerifyDomainRequest,
+} from "../../common/types/api";
+
+export class VerificationService {
+  async verifyDomain(
+    agentId: string,
+    payload: VerifyDomainRequest,
+    publisher: PublisherContext,
+  ): Promise<never> {
+    void agentId;
+    void payload;
+    void publisher;
+
+    throw HttpError.notImplemented(
+      "domain_verification_not_implemented",
+      "Domain verification has not been implemented yet.",
+    );
+  }
+}

--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -1,0 +1,21 @@
+import { Elysia } from "elysia";
+
+import { env } from "../config/env";
+import type { PublisherContext } from "../common/types/api";
+
+export const buildPublisherContext = (request: Request): PublisherContext => {
+  const headerSubject = request.headers.get("x-publisher-subject");
+  const authorization = request.headers.get("authorization");
+
+  return {
+    subject: headerSubject ?? env.DEV_PUBLISHER_SUBJECT,
+    isAuthenticated:
+      Boolean(headerSubject || authorization) || env.NODE_ENV !== "production",
+  };
+};
+
+export const authPlugin = new Elysia({ name: "auth-plugin" }).derive(
+  ({ request }) => ({
+    publisher: buildPublisherContext(request),
+  }),
+);

--- a/src/plugins/cors.ts
+++ b/src/plugins/cors.ts
@@ -1,0 +1,13 @@
+import { cors } from "@elysiajs/cors";
+import { Elysia } from "elysia";
+
+import { env } from "../config/env";
+
+const origin = env.CORS_ORIGIN === "*" ? true : env.CORS_ORIGIN;
+
+export const corsPlugin = new Elysia({ name: "cors-plugin" }).use(
+  cors({
+    origin,
+    credentials: true,
+  }),
+);

--- a/src/plugins/docs.ts
+++ b/src/plugins/docs.ts
@@ -1,0 +1,39 @@
+import { openapi } from "@elysiajs/openapi";
+import { Elysia } from "elysia";
+
+import {
+  APP_NAME,
+  APP_VERSION,
+  DOCS_JSON_PATH,
+  DOCS_PATH,
+} from "../config/constants";
+
+export const docsPlugin = new Elysia({ name: "docs-plugin" }).use(
+  openapi({
+    path: DOCS_PATH,
+    specPath: DOCS_JSON_PATH,
+    provider: "scalar",
+    documentation: {
+      info: {
+        title: `${APP_NAME} API`,
+        version: APP_VERSION,
+        description: "Architecture-first scaffold for the AgentHub registry API.",
+      },
+      tags: [
+        { name: "Health", description: "Service health and readiness routes." },
+        {
+          name: "Publication",
+          description: "Publisher write and administrative routes.",
+        },
+        {
+          name: "Verification",
+          description: "Domain verification routes for pending publications.",
+        },
+        {
+          name: "Discovery",
+          description: "Public lookup and search routes.",
+        },
+      ],
+    },
+  }),
+);

--- a/src/plugins/logger.ts
+++ b/src/plugins/logger.ts
@@ -1,0 +1,33 @@
+import { Elysia } from "elysia";
+
+import { env } from "../config/env";
+
+const shouldLog = env.NODE_ENV !== "test";
+
+export const loggerPlugin = new Elysia({ name: "logger-plugin" })
+  .onRequest(({ request }) => {
+    if (!shouldLog) {
+      return;
+    }
+
+    console.log(`[request] ${request.method} ${new URL(request.url).pathname}`);
+  })
+  .onAfterHandle(({ request, set }) => {
+    if (!shouldLog) {
+      return;
+    }
+
+    console.log(
+      `[response] ${request.method} ${new URL(request.url).pathname} ${set.status}`,
+    );
+  })
+  .onError(({ request, error }) => {
+    if (!shouldLog) {
+      return;
+    }
+
+    console.error(
+      `[error] ${request.method} ${new URL(request.url).pathname}`,
+      error,
+    );
+  });

--- a/src/tests/integration/app.integration.test.ts
+++ b/src/tests/integration/app.integration.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildApp } from "../../app";
+
+describe("app integration", () => {
+  it("returns service health", async () => {
+    const app = buildApp();
+    const response = await app.handle(new Request("http://localhost/health"));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.status).toBe("ok");
+  });
+
+  it("exposes openapi json", async () => {
+    const app = buildApp();
+    const response = await app.handle(
+      new Request("http://localhost/docs/openapi.json"),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.paths["/v1/publish/agents/{agentId}"]).toBeDefined();
+    expect(payload.paths["/v1/agents/search"]).toBeDefined();
+  });
+});

--- a/src/tests/integration/routes.integration.test.ts
+++ b/src/tests/integration/routes.integration.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildApp } from "../../app";
+
+const validPublicationBody = {
+  agent_card_url: "https://travel.example.com/.well-known/agent-card.json",
+  visibility: "public",
+};
+
+describe("route validation and placeholder behavior", () => {
+  it("rejects invalid agent ids", async () => {
+    const app = buildApp();
+    const response = await app.handle(
+      new Request("http://localhost/v1/publish/agents/InvalidId", {
+        method: "GET",
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("invalid_agent_id");
+  });
+
+  it("rejects malformed publish bodies", async () => {
+    const app = buildApp();
+    const response = await app.handle(
+      new Request("http://localhost/v1/publish/agents/acme.travel-planner", {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ visibility: "public" }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("invalid_request_body");
+  });
+
+  it("rejects non-https agent card urls", async () => {
+    const app = buildApp();
+    const response = await app.handle(
+      new Request("http://localhost/v1/publish/agents/acme.travel-planner", {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          agent_card_url: "http://travel.example.com/.well-known/agent-card.json",
+          visibility: "public",
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("invalid_request_body");
+  });
+
+  it("rejects unsupported verification methods", async () => {
+    const app = buildApp();
+    const response = await app.handle(
+      new Request(
+        "http://localhost/v1/publish/agents/acme.travel-planner/verify-domain",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({ method: "dns_txt" }),
+        },
+      ),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(payload.error.code).toBe("invalid_request_body");
+  });
+
+  it("returns typed 501 placeholders for publish routes", async () => {
+    const app = buildApp();
+    const response = await app.handle(
+      new Request("http://localhost/v1/publish/agents/acme.travel-planner", {
+        method: "PUT",
+        headers: {
+          "content-type": "application/json",
+          "x-publisher-subject": "publisher:test",
+        },
+        body: JSON.stringify(validPublicationBody),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(501);
+    expect(payload.error.code).toBe("publication_publish_not_implemented");
+  });
+
+  it("returns typed 501 placeholders for discovery routes", async () => {
+    const app = buildApp();
+    const response = await app.handle(
+      new Request("http://localhost/v1/agents/search", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          query: {
+            text: "travel",
+          },
+        }),
+      }),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(501);
+    expect(payload.error.code).toBe("discovery_search_not_implemented");
+  });
+});

--- a/src/tests/unit/common.unit.test.ts
+++ b/src/tests/unit/common.unit.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+
+import { AppError } from "../../common/errors/app-error";
+import { HttpError } from "../../common/errors/http-error";
+import { generateOpaqueToken } from "../../common/utils/crypto";
+import { addMinutes } from "../../common/utils/time";
+
+describe("common errors", () => {
+  it("serializes app errors into the standard envelope", () => {
+    const error = new AppError({
+      status: 409,
+      code: "duplicate_publication_conflict",
+      message: "Duplicate publication.",
+    });
+
+    expect(error.toResponse()).toEqual({
+      error: {
+        code: "duplicate_publication_conflict",
+        message: "Duplicate publication.",
+        retryable: false,
+        details: undefined,
+      },
+    });
+  });
+
+  it("creates not implemented http errors", () => {
+    const error = HttpError.notImplemented(
+      "publication_publish_not_implemented",
+      "Publishing agents has not been implemented yet.",
+    );
+
+    expect(error.status).toBe(501);
+    expect(error.code).toBe("publication_publish_not_implemented");
+  });
+});
+
+describe("common utilities", () => {
+  it("builds opaque tokens with the requested prefix", () => {
+    const token = generateOpaqueToken("test");
+
+    expect(token.startsWith("test_")).toBe(true);
+  });
+
+  it("adds minutes to a date", () => {
+    const result = addMinutes(new Date("2026-01-01T00:00:00.000Z"), 5);
+
+    expect(result).toBe("2026-01-01T00:05:00.000Z");
+  });
+});

--- a/src/tests/unit/services.unit.test.ts
+++ b/src/tests/unit/services.unit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+
+import { HttpError } from "../../common/errors/http-error";
+import { PublicationService } from "../../modules/publication/publication.service";
+import { VerificationService } from "../../modules/verification/verification.service";
+import { DiscoveryService } from "../../modules/discovery/discovery.service";
+import type {
+  AgentPublication,
+  PublisherContext,
+  SearchEnvelope,
+  VerifyDomainRequest,
+} from "../../common/types/api";
+
+const publisher: PublisherContext = {
+  subject: "publisher:test",
+  isAuthenticated: true,
+};
+
+const publication: AgentPublication = {
+  agent_card_url: "https://travel.example.com/.well-known/agent-card.json",
+  visibility: "public",
+};
+
+const verifyPayload: VerifyDomainRequest = {
+  method: "well_known_token",
+};
+
+const searchPayload: SearchEnvelope = {
+  query: {
+    text: "travel",
+  },
+};
+
+describe("service placeholders", () => {
+  it("publication service throws a typed 501", async () => {
+    const service = new PublicationService({
+      async getByAgentId() {
+        return null;
+      },
+      async upsert() {},
+      async deactivate() {},
+    });
+
+    await expect(
+      service.publishAgent("acme.travel-planner", publication, publisher),
+    ).rejects.toBeInstanceOf(HttpError);
+  });
+
+  it("verification service throws a typed 501", async () => {
+    const service = new VerificationService();
+
+    await expect(
+      service.verifyDomain("acme.travel-planner", verifyPayload, publisher),
+    ).rejects.toBeInstanceOf(HttpError);
+  });
+
+  it("discovery service throws a typed 501", async () => {
+    const service = new DiscoveryService({
+      async getByAgentId() {
+        return null;
+      },
+      async search() {
+        return {
+          results: [],
+          next_page_token: null,
+        };
+      },
+    });
+
+    await expect(service.searchAgents(searchPayload)).rejects.toBeInstanceOf(
+      HttpError,
+    );
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     /* Modules */
     "module": "ES2022",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "bundler",                    /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
## Summary
- replace the Bun/Elysia starter with a modular AgentHub app scaffold using the requested project layout
- add shared config, plugins, common API/error types, and PostgreSQL/Drizzle plus Redis infrastructure seams
- scaffold publication, verification, and discovery modules with typed `501` placeholder services and OpenAPI-backed validation/docs
- add unit and integration coverage for health, docs, validation behavior, and placeholder route responses

## Testing
- `bun test`
- `bunx tsc --noEmit`