### PR TITLE
docs: add repo agents guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+## Purpose
+
+- This repo is the reference implementation of [caelaxie/agenthub-spec](https://github.com/caelaxie/agenthub-spec).
+- The spec repo is canonical for public API and product behavior.
+- If code in this repo differs from the spec, treat it as an implementation gap to fix, not alternate policy.
+
+## Source Of Truth
+
+- Follow `agenthub-spec` for registry contract, lifecycle, data model, and endpoint behavior.
+- Keep local implementation, shared schemas, OpenAPI output, and tests aligned with that contract.
+- Do not invent public behavior locally unless the user explicitly asks to change the spec as well.
+
+## Repo Map
+
+- `src/modules/*`: publication, verification, discovery, and route/service logic.
+- `src/common/types/api.ts`: shared request and response schemas.
+- `src/app.ts`: app wiring, plugins, route registration, and error handling.
+
+## Commands
+
+- `bun run dev`
+- `bun test`
+- `bun run db:generate`
+- `bun run db:migrate`
+
+## Change Rules
+
+- For any public-contract change, update implementation, schemas/OpenAPI, and tests in the same task.
+- Keep placeholder behavior explicit. Missing features should fail as not implemented, not silently redefine the contract.
+- Use Context7 for external library or API documentation.
+
+## Validation Bar
+
+- Verify referenced commands and paths still exist.
+- Keep OpenAPI and typed schemas consistent with implemented routes.
+- Prefer regression tests when fixing contract or behavior bugs.


### PR DESCRIPTION
## Summary
Adds a concise root AGENTS.md for the AgentHub reference implementation.
It makes the external spec repo canonical and sets the minimum repo rules needed to keep implementation work aligned.

## Key Changes
- Marks this repo as the reference implementation of caelaxie/agenthub-spec and treats divergence as an implementation gap to fix (AGENTS.md:5).
- Defines the source-of-truth rule for contract, lifecycle, data model, and endpoint behavior (AGENTS.md:11).
- Points contributors at the main implementation surfaces: src/modules/*, src/common/types/api.ts, and src/app.ts (AGENTS.md:17).
- Lists the primary local development and database commands used in this repo (AGENTS.md:23).
- Requires public-contract changes to update implementation, schemas/OpenAPI, and tests together (AGENTS.md:30).
- Keeps not-implemented behavior explicit and directs contributors to use Context7 for external library and API docs (AGENTS.md:31).
