### PR TITLE
feat: implement domain verification flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ bun run dev
 For a step-by-step local QA guide covering Postman requests, happy paths, and
 known placeholder routes, see [`docs/manual-testing.md`](docs/manual-testing.md).
 
+For the publish-to-active domain verification flow and its ownership model, see
+[`docs/domain-verification-workflow.md`](docs/domain-verification-workflow.md).
+
 ## Docker
 
 Build the production image:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ For a fresh local database, apply the generated migrations:
 bun run db:migrate
 ```
 
+To inspect the local database in Drizzle Studio:
+
+```bash
+bun run db:studio
+```
+
 Start the app:
 
 ```bash

--- a/docs/domain-verification-workflow.md
+++ b/docs/domain-verification-workflow.md
@@ -1,0 +1,287 @@
+# Domain Verification Workflow
+
+This page is a maintainer guide to the publish-to-active flow around
+`POST /v1/publish/agents/{agent_id}/verify-domain`.
+
+If you are new to the repo, the main point to keep in mind is simple:
+
+- `PUT /publish` proves the registry can fetch and normalize a card
+- `POST /verify-domain` proves the publisher controls the canonical card origin
+- only after both succeed may a record become `active`
+
+## Why This Exists
+
+The registry must not make an entry discoverable just because a caller knows a
+valid `agent_card_url`.
+
+Without domain verification:
+
+- a caller could publish someone else's Agent Card URL
+- a caller could try to bind a namespace it does not control
+- the registry could expose a discoverable entry without proof that the
+  publisher controls the canonical card origin
+
+Domain verification is the control that binds:
+
+- the publisher subject
+- the namespace
+- the canonical Agent Card origin
+
+into one verified ownership boundary.
+
+## Maintainer Mental Model
+
+Think of the workflow as a two-phase gate.
+
+```text
+Phase 1: Publish
+  "Is this card fetchable, valid, and normalizable?"
+
+Phase 2: Verify Domain
+  "Does this publisher control the same HTTPS origin as the canonical card?"
+
+Only if both are true:
+  pending_verification -> active
+```
+
+This separation is intentional:
+
+- publish is about card validity and registry-owned normalization
+- verify is about ownership of the canonical origin
+- activation requires both
+
+## Happy Path
+
+```text
+Publisher                  AgentHub                    Agent Card Origin
+   |                          |                               |
+   | PUT /v1/publish/agents/{agent_id}                        |
+   | agent_card_url=https://travel.example.com/...            |
+   |------------------------->|                               |
+   |                          | GET canonical Agent Card      |
+   |                          |------------------------------>|
+   |                          | validate + normalize snapshot |
+   |                          | write pending publication     |
+   |                          | write challenge               |
+   |<-------------------------|                               |
+   | 201/200 pending_verification + challenge                 |
+   |                                                          |
+   | serve verification file at                               |
+   | /.well-known/agenthub-verification/{agent_id}            |
+   |                                                          |
+   | body must be exactly:                                    |
+   | agent_id=acme.travel-planner                             |
+   | token=ahv1_...                                           |
+   |                                                          |
+   | POST /v1/publish/agents/{agent_id}/verify-domain         |
+   |------------------------->|                               |
+   |                          | read stored publication       |
+   |                          | read stored challenge         |
+   |                          | GET stored challenge URL      |
+   |                          |------------------------------>|
+   |                          | require same HTTPS origin     |
+   |                          | require exact body match      |
+   |                          | claim namespace if unowned    |
+   |                          | mark publication active       |
+   |                          | delete challenge              |
+   |<-------------------------|                               |
+   | 200 active + verified_at                                 |
+```
+
+## State Machine
+
+For this flow, the critical transition is:
+
+```text
+new publication
+   |
+   v
+pending_verification
+   |
+   | verify-domain succeeds
+   v
+active
+```
+
+Important implication for maintainers:
+
+- publish must never skip directly to `active`
+- verify must not activate records outside `pending_verification`
+- `active` records should not carry an outstanding verification challenge
+
+## What Each Endpoint Owns
+
+```text
+PUT /v1/publish/agents/{agent_id}
+  - validates agent_id and request shape
+  - fetches canonical Agent Card
+  - validates enough card structure for discovery
+  - normalizes registry-owned snapshot fields
+  - writes publication as pending_verification
+  - issues or refreshes a well-known challenge
+  - does not activate the record
+
+POST /v1/publish/agents/{agent_id}/verify-domain
+  - requires authenticated owner access
+  - reads stored challenge state
+  - rejects expired or missing active challenge state
+  - fetches the stored well-known verification URL
+  - enforces same-origin HTTPS redirects only
+  - requires exact body match
+  - claims namespace on first success
+  - marks record active
+  - clears challenge state
+```
+
+## Registry-Owned State
+
+The verification flow updates three pieces of persisted state.
+
+```text
+agent_publications
+  - holds lifecycle state
+  - starts as pending_verification after publish
+  - becomes active after successful verify-domain
+  - stores verified_at once verification succeeds
+
+verification_challenges
+  - holds the current well_known_token challenge
+  - is created or refreshed during publish
+  - is deleted after successful verification
+
+namespaces
+  - holds namespace ownership
+  - is populated on first successful verification for an unclaimed namespace
+  - becomes the authorization source for later admin operations
+```
+
+Another way to read the same flow:
+
+```text
+publish writes:
+  agent_publications + agent_snapshots + verification_challenges
+
+verify-domain writes:
+  namespaces (if needed) + agent_publications + delete verification_challenges
+```
+
+## Namespace Binding
+
+Namespace ownership is not finalized at publish time. It is finalized on first
+successful domain verification.
+
+```text
+before verification:
+  namespace "acme" -> unowned
+  publication "acme.travel-planner" -> pending_owner_subject=publisher:test
+
+after first successful verification:
+  namespace "acme" -> owner_subject=publisher:test
+  publication "acme.travel-planner" -> active
+
+after that:
+  publish/get/verify/deactivate for acme.*
+  -> must come from that owner subject
+```
+
+This is the main reason verification is part of the ownership model rather than
+just a discovery-health check.
+
+## Exact Proof Rules
+
+New team members usually need this section when debugging failed verification.
+
+The verification fetch is strict by design:
+
+- the URL comes from stored challenge state, not from the request body
+- the verification resource must stay on the same scheme, host, and port as
+  `agent_card_ref.source_url`
+- redirects are allowed only when every hop stays on that same HTTPS origin
+- the final response must be `200 OK`
+- the body must be exactly:
+
+```text
+agent_id=<agent_id>
+token=<challenge token>
+```
+
+- one trailing newline is allowed
+- any other body shape fails verification
+
+Treat this as an ownership proof, not a best-effort heuristic.
+
+## Failure Cases
+
+These are the failure modes that matter most in code review and debugging.
+
+```text
+Case: challenge expired
+pending_verification -> verify-domain -> 409 verification_challenge_expired
+
+Case: wrong file body
+pending_verification -> verify-domain -> 403 domain_verification_failed
+
+Case: file missing / non-200
+pending_verification -> verify-domain -> 403 domain_verification_failed
+
+Case: redirect changes origin
+pending_verification -> verify-domain -> 403 domain_verification_failed
+
+Case: redirect changes HTTPS status
+pending_verification -> verify-domain -> 403 domain_verification_failed
+
+Case: wrong owner tries to verify
+pending_verification -> verify-domain -> 403 publication_forbidden
+
+Case: record is already active
+active -> verify-domain -> reject as ineligible
+```
+
+## Where To Read The Code
+
+For onboarding, these are the highest-value entry points:
+
+- `src/modules/publication/publication.service.ts`
+  publish-time validation, normalization, and challenge issuance
+- `src/modules/verification/verification.service.ts`
+  verify-time ownership checks, proof fetching, and activation
+- `src/modules/publication/publication.repo.ts`
+  atomic persistence transitions, including namespace claim and challenge cleanup
+- `src/common/types/api.ts`
+  public request and response shapes
+- `src/tests/unit/services.unit.test.ts`
+  service-level verification scenarios
+- `src/tests/integration/routes.integration.test.ts`
+  route-level verification behavior and error envelopes
+
+Read those in that order if you are trying to understand the feature from
+scratch.
+
+## Maintainer Debug Checklist
+
+When verification fails unexpectedly, check these in order:
+
+1. Is the publication still `pending_verification`?
+2. Does the record still have a stored challenge?
+3. Is the challenge still unexpired?
+4. Does the stored challenge URL stay on the same HTTPS origin as
+   `agent_card_ref.source_url`?
+5. Does the served body exactly match `agent_id=...` and `token=...`?
+6. Is the caller the pending owner or bound namespace owner?
+7. After success, was the namespace claimed and was the challenge deleted?
+
+If one of these is false, the failure is usually correct.
+
+## Review Invariants
+
+When reviewing changes in this area, preserve these invariants:
+
+- verification must use stored challenge state, not caller-supplied origin data
+- publish must not activate a record
+- verification must not bypass owner checks
+- namespace claim must happen on first successful verification, not before
+- challenge state must not remain active after successful verification
+- redirects must never allow origin drift
+
+If a change weakens any of those, it is likely changing the ownership model,
+not just refactoring implementation details.

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -398,9 +398,6 @@ Expect:
 
 ## Discovery and Verification Notes
 
-These routes are not fully implemented yet and should currently be treated as
-placeholder behavior during manual testing.
-
 ### Domain Verification
 
 Request:
@@ -419,10 +416,21 @@ Body:
 }
 ```
 
-Current expectation:
+Successful verification expectations:
 
-- `501 Not Implemented`
-- `error.code = "domain_verification_not_implemented"`
+- `200 OK`
+- response status becomes `active`
+- response includes `verified_at`
+- owner-only `GET /v1/publish/agents/{{agentId}}` no longer includes `challenge`
+
+Failure cases to verify:
+
+- expired or missing active challenge returns `409`
+- `error.code = "verification_challenge_expired"`
+- wrong body, missing file, or cross-origin redirect returns `403`
+- `error.code = "domain_verification_failed"`
+- wrong owner subject returns `403`
+- `error.code = "publication_forbidden"`
 
 ### Discovery Search
 

--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -4,9 +4,43 @@ This runbook is for developers and QA engineers validating the API locally.
 It uses Postman as the primary workflow, with a few `curl` examples for quick
 spot checks.
 
-The current implementation supports the publication lifecycle endpoints. Domain
-verification and discovery are still placeholder flows and are called out below
-so they are not mistaken for fully implemented features.
+The current implementation supports the publication lifecycle endpoints and
+domain verification. Discovery remains a placeholder flow and is called out
+below so it is not mistaken for a fully implemented feature.
+
+## Table Of Contents
+
+- [Prerequisites](#prerequisites)
+- [Local Dummy Agent Card Server](#local-dummy-agent-card-server)
+- [Postman Setup](#postman-setup)
+- [Recommended Local Flow](#recommended-local-flow)
+- [Smoke Checks](#smoke-checks)
+  - [Health](#health)
+  - [OpenAPI Document](#openapi-document)
+- [Publication Lifecycle Checks](#publication-lifecycle-checks)
+  - [Publish Success](#publish-success)
+  - [Re-publish Same Origin](#re-publish-same-origin)
+  - [Owner-only Publication Read](#owner-only-publication-read)
+  - [Deactivate](#deactivate)
+- [Negative-path Checks](#negative-path-checks)
+  - [Invalid Agent ID](#invalid-agent-id)
+  - [Malformed Publish Body](#malformed-publish-body)
+  - [Non-HTTPS Agent Card URL](#non-https-agent-card-url)
+  - [Unauthorized Owner-only Access](#unauthorized-owner-only-access)
+  - [Namespace Conflict](#namespace-conflict)
+  - [Cross-origin Re-publish](#cross-origin-re-publish)
+  - [Duplicate Active Source URL](#duplicate-active-source-url)
+  - [Upstream Card Fetch Failure](#upstream-card-fetch-failure)
+  - [Malformed Agent Card](#malformed-agent-card)
+- [Discovery and Verification Notes](#discovery-and-verification-notes)
+  - [Domain Verification](#domain-verification)
+  - [Discovery Search](#discovery-search)
+  - [Exact Discovery Lookup](#exact-discovery-lookup)
+- [Troubleshooting](#troubleshooting)
+  - [Database or migration issues](#database-or-migration-issues)
+  - [Agent Card fetch failures](#agent-card-fetch-failures)
+  - [Auth mistakes](#auth-mistakes)
+  - [Placeholder routes](#placeholder-routes)
 
 ## Prerequisites
 
@@ -85,6 +119,7 @@ Default URLs:
 
 - Agent Card: `https://localhost:8443/.well-known/agent-card.json`
 - Interface endpoint: `https://localhost:8443/a2a`
+- Verification admin endpoint: `https://localhost:8443/__admin/verification`
 
 The script exits with setup instructions if the TLS files are missing. You can
 override the defaults with:
@@ -94,6 +129,30 @@ override the defaults with:
 - `DUMMY_AGENT_CARD_BIND_HOST`
 - `DUMMY_AGENT_CARD_CERT_PATH`
 - `DUMMY_AGENT_CARD_KEY_PATH`
+
+After a publish response returns a `challenge.token`, configure the dummy
+server with:
+
+```bash
+curl https://localhost:8443/__admin/verification \
+  -H 'content-type: application/json' \
+  -d '{
+    "agent_id": "acme.travel-planner",
+    "token": "ahv1_your_token_here"
+  }'
+```
+
+That makes the server return the exact expected body from:
+
+```text
+https://localhost:8443/.well-known/agenthub-verification/acme.travel-planner
+```
+
+You can inspect the currently configured agent ids with:
+
+```bash
+curl https://localhost:8443/__admin/verification
+```
 
 ## Postman Setup
 
@@ -121,6 +180,32 @@ For publication routes, send:
 | --- | --- |
 | `Content-Type` | `application/json` |
 | `Authorization` | `{{publisherToken}}` |
+
+Important note:
+
+- In the current dev auth implementation, the raw `Authorization` header value
+  becomes the publisher subject.
+- Use the same `Authorization` header value for publish, owner-only read,
+  verify-domain, and deactivate when testing a single publication lifecycle.
+- If you switch from `Bearer publisher-token` to a different string later in
+  the flow, owner checks will fail with `403 publication_forbidden`.
+
+## Recommended Local Flow
+
+For the lowest-friction local test flow, run the steps in this order:
+
+1. `docker compose up -d`
+2. `bun run db:migrate`
+3. `bun run dev:dummy-agent-card`
+4. `bun run dev:with-local-ca`
+5. `PUT /v1/publish/agents/{{agentId}}`
+6. copy `challenge.token` from the publish response
+7. `POST https://localhost:8443/__admin/verification` with `agent_id` and `token`
+8. `POST /v1/publish/agents/{{agentId}}/verify-domain`
+9. `GET /v1/publish/agents/{{agentId}}` to confirm `status = "active"`
+
+This sequence exercises the full publish-to-active path on one local HTTPS
+origin and avoids external upstream dependencies.
 
 ## Smoke Checks
 
@@ -423,6 +508,8 @@ Successful verification expectations:
 - response includes `verified_at`
 - owner-only `GET /v1/publish/agents/{{agentId}}` no longer includes `challenge`
 
+For the recommended local sequence, see [Recommended Local Flow](#recommended-local-flow).
+
 Failure cases to verify:
 
 - expired or missing active challenge returns `409`
@@ -516,5 +603,6 @@ Symptoms:
 
 Checks:
 
-- confirm you are testing discovery or domain verification, which are still
-  expected placeholders in the current repo state
+- confirm you are testing a discovery route
+- `POST /v1/publish/agents/{agent_id}/verify-domain` is implemented and should
+  not still return `501`

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1056,34 +1056,6 @@ paths:
                         type: object
                         properties: {}
                 $id: "#/components/schemas/ErrorEnvelope"
-        "501":
-          description: Response for status 501
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                  - error
-                properties:
-                  error:
-                    type: object
-                    required:
-                      - code
-                      - message
-                      - retryable
-                      - details
-                    properties:
-                      code:
-                        type: string
-                      message:
-                        type: string
-                      retryable:
-                        type: boolean
-                      details:
-                        additionalProperties: true
-                        type: object
-                        properties: {}
-                $id: "#/components/schemas/ErrorEnvelope"
       operationId: postV1PublishAgentsByAgentIdVerify-domain
   /v1/agents/{agentId}:
     get:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "docs:openapi:check": "bun run scripts/generate-openapi-docs.ts --check",
     "dev:dummy-agent-card": "bun run scripts/serve-dummy-agent-card.ts",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit migrate"
+    "db:migrate": "drizzle-kit migrate",
+    "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
     "@elysiajs/cors": "latest",

--- a/scripts/lib/dummy-agent-card-server.ts
+++ b/scripts/lib/dummy-agent-card-server.ts
@@ -1,0 +1,155 @@
+export const dummyAgentCardPath = "/.well-known/agent-card.json";
+export const dummyVerificationPathPrefix =
+  "/.well-known/agenthub-verification/";
+export const dummyVerificationAdminPath = "/__admin/verification";
+
+interface DummyAgentCardServerOptions {
+  baseUrl: string;
+  cardUrl: string;
+}
+
+interface VerificationPayload {
+  agent_id: string;
+  token: string;
+}
+
+export const buildVerificationBody = (
+  agentId: string,
+  token: string,
+): string => `agent_id=${agentId}\ntoken=${token}\n`;
+
+const isVerificationPayload = (
+  payload: unknown,
+): payload is VerificationPayload => {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  const value = payload as Record<string, unknown>;
+
+  return (
+    typeof value.agent_id === "string" &&
+    value.agent_id.trim().length > 0 &&
+    typeof value.token === "string" &&
+    value.token.trim().length > 0
+  );
+};
+
+const createCardPayload = (baseUrl: string) => ({
+  name: "Local Dummy Agent",
+  provider: "AgentHub Manual Testing",
+  supportedInterfaces: [
+    {
+      url: `${baseUrl}/a2a`,
+      protocolBinding: "HTTP+JSON",
+      protocolVersion: "1.0",
+    },
+  ],
+  skills: [
+    {
+      id: "manual-test",
+      tags: ["Testing", "Local"],
+    },
+  ],
+});
+
+export const createDummyAgentCardFetchHandler = ({
+  baseUrl,
+  cardUrl,
+}: DummyAgentCardServerOptions) => {
+  const verificationTokens = new Map<string, string>();
+  const cardPayload = createCardPayload(baseUrl);
+
+  return async (request: Request): Promise<Response> => {
+    const { pathname } = new URL(request.url);
+
+    if (pathname === dummyAgentCardPath) {
+      return Response.json(cardPayload, {
+        headers: {
+          "cache-control": "no-store",
+        },
+      });
+    }
+
+    if (pathname === "/a2a") {
+      return Response.json({
+        ok: true,
+        agent: cardPayload.name,
+      });
+    }
+
+    if (pathname === dummyVerificationAdminPath && request.method === "POST") {
+      let payload: unknown;
+
+      try {
+        payload = await request.json();
+      } catch {
+        return Response.json(
+          {
+            error: "invalid_json",
+          },
+          { status: 400 },
+        );
+      }
+
+      if (!isVerificationPayload(payload)) {
+        return Response.json(
+          {
+            error: "invalid_verification_payload",
+            expected: {
+              agent_id: "acme.travel-planner",
+              token: "ahv1_...",
+            },
+          },
+          { status: 400 },
+        );
+      }
+
+      verificationTokens.set(payload.agent_id, payload.token);
+
+      return Response.json({
+        status: "configured",
+        agent_id: payload.agent_id,
+        verification_url: `${baseUrl}${dummyVerificationPathPrefix}${payload.agent_id}`,
+      });
+    }
+
+    if (pathname === dummyVerificationAdminPath && request.method === "GET") {
+      return Response.json({
+        configured_agent_ids: [...verificationTokens.keys()],
+      });
+    }
+
+    if (pathname.startsWith(dummyVerificationPathPrefix)) {
+      const agentId = decodeURIComponent(
+        pathname.slice(dummyVerificationPathPrefix.length),
+      );
+      const token = verificationTokens.get(agentId);
+
+      if (!token) {
+        return new Response("Not found", { status: 404 });
+      }
+
+      return new Response(buildVerificationBody(agentId, token), {
+        headers: {
+          "content-type": "text/plain; charset=utf-8",
+          "cache-control": "no-store",
+        },
+      });
+    }
+
+    if (pathname === "/") {
+      return Response.json({
+        card_url: cardUrl,
+        supported_paths: [
+          dummyAgentCardPath,
+          "/a2a",
+          `${dummyVerificationPathPrefix}{agent_id}`,
+          dummyVerificationAdminPath,
+        ],
+      });
+    }
+
+    return new Response("Not found", { status: 404 });
+  };
+};

--- a/scripts/serve-dummy-agent-card.ts
+++ b/scripts/serve-dummy-agent-card.ts
@@ -1,6 +1,12 @@
 import { access } from "node:fs/promises";
 import path from "node:path";
 
+import {
+  createDummyAgentCardFetchHandler,
+  dummyVerificationAdminPath,
+  dummyVerificationPathPrefix,
+} from "./lib/dummy-agent-card-server";
+
 const REPO_ROOT = path.join(import.meta.dir, "..");
 const DEFAULT_CERT_PATH = path.join(REPO_ROOT, ".certs", "localhost.pem");
 const DEFAULT_KEY_PATH = path.join(REPO_ROOT, ".certs", "localhost-key.pem");
@@ -15,26 +21,7 @@ const certPath = process.env.DUMMY_AGENT_CARD_CERT_PATH ?? DEFAULT_CERT_PATH;
 const keyPath = process.env.DUMMY_AGENT_CARD_KEY_PATH ?? DEFAULT_KEY_PATH;
 
 const baseUrl = `https://${publicHost}:${port}`;
-const cardPath = "/.well-known/agent-card.json";
-const cardUrl = `${baseUrl}${cardPath}`;
-
-const cardPayload = {
-  name: "Local Dummy Agent",
-  provider: "AgentHub Manual Testing",
-  supportedInterfaces: [
-    {
-      url: `${baseUrl}/a2a`,
-      protocolBinding: "HTTP+JSON",
-      protocolVersion: "1.0",
-    },
-  ],
-  skills: [
-    {
-      id: "manual-test",
-      tags: ["Testing", "Local"],
-    },
-  ],
-};
+const cardUrl = `${baseUrl}/.well-known/agent-card.json`;
 
 const ensureTlsFiles = async () => {
   try {
@@ -64,34 +51,17 @@ const server = Bun.serve({
     cert: Bun.file(certPath),
     key: Bun.file(keyPath),
   },
-  fetch(request) {
-    const { pathname } = new URL(request.url);
-
-    if (pathname === cardPath) {
-      return Response.json(cardPayload, {
-        headers: {
-          "cache-control": "no-store",
-        },
-      });
-    }
-
-    if (pathname === "/a2a") {
-      return Response.json({
-        ok: true,
-        agent: cardPayload.name,
-      });
-    }
-
-    if (pathname === "/") {
-      return Response.json({
-        card_url: cardUrl,
-        supported_paths: [cardPath, "/a2a"],
-      });
-    }
-
-    return new Response("Not found", { status: 404 });
-  },
+  fetch: createDummyAgentCardFetchHandler({
+    baseUrl,
+    cardUrl,
+  }),
 });
 
 console.log(`Dummy Agent Card server listening on https://${publicHost}:${server.port}`);
 console.log(`Agent Card URL: ${cardUrl}`);
+console.log(
+  `Verification admin URL: https://${publicHost}:${server.port}${dummyVerificationAdminPath}`,
+);
+console.log(
+  `Verification path template: https://${publicHost}:${server.port}${dummyVerificationPathPrefix}{agent_id}`,
+);

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,7 +12,10 @@ import {
   createPublicationPlugin,
 } from "./modules/publication/publication.plugin";
 import type { PublicationService } from "./modules/publication/publication.service";
-import { verificationPlugin } from "./modules/verification/verification.plugin";
+import {
+  createVerificationPlugin,
+} from "./modules/verification/verification.plugin";
+import type { VerificationService } from "./modules/verification/verification.service";
 import { discoveryPlugin } from "./modules/discovery/discovery.plugin";
 
 const mapUnknownError = (error: unknown) => {
@@ -71,6 +74,7 @@ const readValidationDetails = (error: unknown): Record<string, unknown> => {
 
 export interface AppDependencies {
   publicationService?: PublicationService;
+  verificationService?: VerificationService;
 }
 
 export const buildApp = (dependencies: AppDependencies = {}) =>
@@ -84,7 +88,7 @@ export const buildApp = (dependencies: AppDependencies = {}) =>
     .use(authPlugin)
     .use(healthRoute)
     .use(createPublicationPlugin(dependencies.publicationService))
-    .use(verificationPlugin)
+    .use(createVerificationPlugin(dependencies.verificationService))
     .use(discoveryPlugin)
     .onError(({ code, error, set }) => {
       if (code === "VALIDATION") {

--- a/src/modules/publication/publication.repo.ts
+++ b/src/modules/publication/publication.repo.ts
@@ -18,6 +18,11 @@ export interface PublicationRepository {
   getNamespaceOwner(namespace: string): Promise<string | null>;
   findActiveBySourceUrl(sourceUrl: string): Promise<{ agentId: string } | null>;
   upsert(record: UpsertPublicationRecord): Promise<void>;
+  completeVerification(
+    agentId: string,
+    publisherSubject: string,
+    verifiedAt: string,
+  ): Promise<void>;
   deactivate(agentId: string): Promise<void>;
 }
 
@@ -237,6 +242,66 @@ export class DrizzlePublicationRepository implements PublicationRepository {
             refreshedAt: timestamp,
           },
         });
+    });
+  }
+
+  async completeVerification(
+    agentId: string,
+    publisherSubject: string,
+    verifiedAt: string,
+  ): Promise<void> {
+    const db = requireDb();
+    const verifiedTimestamp = new Date(verifiedAt);
+
+    await db.transaction(async (tx) => {
+      const [publication] = await tx
+        .select({ namespace: publicationsTable.namespace })
+        .from(publicationsTable)
+        .where(eq(publicationsTable.agentId, agentId))
+        .limit(1);
+
+      if (!publication) {
+        throw HttpError.notFound(
+          "agent_not_found",
+          `No publication found for agent_id '${agentId}'.`,
+        );
+      }
+
+      await tx
+        .insert(namespacesTable)
+        .values({
+          namespace: publication.namespace,
+          ownerSubject: publisherSubject,
+        })
+        .onConflictDoNothing();
+
+      const [namespaceRow] = await tx
+        .select({ ownerSubject: namespacesTable.ownerSubject })
+        .from(namespacesTable)
+        .where(eq(namespacesTable.namespace, publication.namespace))
+        .limit(1);
+
+      if (!namespaceRow || namespaceRow.ownerSubject !== publisherSubject) {
+        throw HttpError.forbidden(
+          "publication_forbidden",
+          "The caller does not own this publication record.",
+        );
+      }
+
+      await tx
+        .update(publicationsTable)
+        .set({
+          status: "active",
+          pendingOwnerSubject: null,
+          verifiedAt: verifiedTimestamp,
+          lastError: null,
+          updatedAt: verifiedTimestamp,
+        })
+        .where(eq(publicationsTable.agentId, agentId));
+
+      await tx
+        .delete(verificationChallengesTable)
+        .where(eq(verificationChallengesTable.agentId, agentId));
     });
   }
 

--- a/src/modules/verification/verification.plugin.ts
+++ b/src/modules/verification/verification.plugin.ts
@@ -3,9 +3,14 @@ import { Elysia } from "elysia";
 import { createVerificationRoutes } from "./verification.route";
 import { VerificationService } from "./verification.service";
 
-const verificationService = new VerificationService();
+export const createVerificationService = () => new VerificationService();
 
-export const verificationPlugin = new Elysia({
-  name: "verification-plugin",
-  prefix: "/v1/publish/agents",
-}).use(createVerificationRoutes(verificationService));
+export const createVerificationPlugin = (
+  service: VerificationService = createVerificationService(),
+) =>
+  new Elysia({
+    name: "verification-plugin",
+    prefix: "/v1/publish/agents",
+  }).use(createVerificationRoutes(service));
+
+export const verificationPlugin = createVerificationPlugin();

--- a/src/modules/verification/verification.route.ts
+++ b/src/modules/verification/verification.route.ts
@@ -28,7 +28,6 @@ export const createVerificationRoutes = (service: VerificationService) =>
         403: verificationErrorResponseSchema,
         404: verificationErrorResponseSchema,
         409: verificationErrorResponseSchema,
-        501: verificationErrorResponseSchema,
       },
       detail: {
         summary: "Verify domain ownership for a pending publication",

--- a/src/modules/verification/verification.service.ts
+++ b/src/modules/verification/verification.service.ts
@@ -1,22 +1,203 @@
 import { HttpError } from "../../common/errors/http-error";
+import { nowIso } from "../../common/utils/time";
 import type {
   PublisherContext,
   VerifyDomainRequest,
+  VerifyDomainResponse,
 } from "../../common/types/api";
+import type { FetchLike } from "../publication/publication.service";
+import {
+  DrizzlePublicationRepository,
+  type PublicationRepository,
+} from "../publication/publication.repo";
+import type { StoredPublicationRecord } from "../publication/publication.entity";
 
 export class VerificationService {
+  constructor(
+    private readonly publicationRepo: PublicationRepository = new DrizzlePublicationRepository(),
+    private readonly fetchImpl: FetchLike = fetch,
+  ) {}
+
   async verifyDomain(
     agentId: string,
     payload: VerifyDomainRequest,
     publisher: PublisherContext,
-  ): Promise<never> {
-    void agentId;
-    void payload;
-    void publisher;
+  ): Promise<VerifyDomainResponse> {
+    this.assertAuthenticated(publisher);
+    this.assertSupportedMethod(payload);
 
-    throw HttpError.notImplemented(
-      "domain_verification_not_implemented",
-      "Domain verification has not been implemented yet.",
+    const record = await this.requirePublication(agentId);
+    this.assertCanAdminister(record, publisher);
+    this.assertEligibleForVerification(record);
+
+    const challenge = record.challenge;
+
+    if (!challenge || this.isExpired(challenge.expires_at)) {
+      throw HttpError.conflict(
+        "verification_challenge_expired",
+        "The stored verification challenge is no longer active.",
+      );
+    }
+
+    await this.verifyChallengeResponse(record, challenge.url, challenge.token);
+
+    const verifiedAt = nowIso();
+    await this.publicationRepo.completeVerification(
+      record.agentId,
+      publisher.subject,
+      verifiedAt,
     );
+
+    return {
+      agent_id: record.agentId,
+      status: "active",
+      verified_at: verifiedAt,
+    };
+  }
+
+  private assertAuthenticated(publisher: PublisherContext): void {
+    if (!publisher.isAuthenticated) {
+      throw HttpError.unauthorized(
+        "publisher_auth_required",
+        "Publisher authentication is required.",
+      );
+    }
+  }
+
+  private assertSupportedMethod(payload: VerifyDomainRequest): void {
+    if (payload.method !== "well_known_token") {
+      throw HttpError.badRequest(
+        "invalid_request_body",
+        "The request failed validation.",
+      );
+    }
+  }
+
+  private async requirePublication(
+    agentId: string,
+  ): Promise<StoredPublicationRecord> {
+    const record = await this.publicationRepo.getByAgentId(agentId);
+
+    if (!record) {
+      throw HttpError.notFound(
+        "agent_not_found",
+        `No publication found for agent_id '${agentId}'.`,
+      );
+    }
+
+    return record;
+  }
+
+  private assertCanAdminister(
+    record: StoredPublicationRecord,
+    publisher: PublisherContext,
+  ): void {
+    const ownerSubject =
+      record.namespaceOwnerSubject ?? record.pendingOwnerSubject;
+
+    if (!ownerSubject || ownerSubject !== publisher.subject) {
+      throw HttpError.forbidden(
+        "publication_forbidden",
+        "The caller does not own this publication record.",
+      );
+    }
+  }
+
+  private assertEligibleForVerification(record: StoredPublicationRecord): void {
+    if (record.status !== "pending_verification") {
+      throw HttpError.conflict(
+        "verification_challenge_expired",
+        "The stored verification challenge is no longer active.",
+      );
+    }
+  }
+
+  private isExpired(expiresAt: string): boolean {
+    return Number.isNaN(Date.parse(expiresAt)) || Date.parse(expiresAt) <= Date.now();
+  }
+
+  private async verifyChallengeResponse(
+    record: StoredPublicationRecord,
+    verificationUrl: string,
+    token: string,
+  ): Promise<void> {
+    const expectedOrigin = new URL(record.agentCardRef.source_url).origin;
+    const expectedBody = `agent_id=${record.agentId}\ntoken=${token}`;
+
+    let currentUrl = verificationUrl;
+
+    for (let redirectCount = 0; redirectCount < 5; redirectCount += 1) {
+      let response: Response;
+
+      try {
+        response = await this.fetchImpl(currentUrl, {
+          method: "GET",
+          redirect: "manual",
+          headers: {
+            accept: "text/plain",
+          },
+        });
+      } catch (error) {
+        throw new HttpError({
+          status: 403,
+          code: "domain_verification_failed",
+          message: "Domain ownership proof could not be verified.",
+          retryable: true,
+          details: {
+            cause: error instanceof Error ? error.message : "unknown",
+          },
+        });
+      }
+
+      if (this.isRedirect(response.status)) {
+        const location = response.headers.get("location");
+
+        if (!location) {
+          throw HttpError.forbidden(
+            "domain_verification_failed",
+            "Domain ownership proof could not be verified.",
+          );
+        }
+
+        const nextUrl = new URL(location, currentUrl);
+
+        if (nextUrl.protocol !== "https:" || nextUrl.origin !== expectedOrigin) {
+          throw HttpError.forbidden(
+            "domain_verification_failed",
+            "Domain ownership proof could not be verified.",
+          );
+        }
+
+        currentUrl = nextUrl.toString();
+        continue;
+      }
+
+      if (response.status !== 200) {
+        throw HttpError.forbidden(
+          "domain_verification_failed",
+          "Domain ownership proof could not be verified.",
+        );
+      }
+
+      const body = await response.text();
+
+      if (body !== expectedBody && body !== `${expectedBody}\n`) {
+        throw HttpError.forbidden(
+          "domain_verification_failed",
+          "Domain ownership proof could not be verified.",
+        );
+      }
+
+      return;
+    }
+
+    throw HttpError.forbidden(
+      "domain_verification_failed",
+      "Domain ownership proof could not be verified.",
+    );
+  }
+
+  private isRedirect(status: number): boolean {
+    return status >= 300 && status < 400;
   }
 }

--- a/src/tests/helpers/publication-test-helpers.ts
+++ b/src/tests/helpers/publication-test-helpers.ts
@@ -1,4 +1,5 @@
 import type {
+  PublisherContext,
   AgentPublicationInput,
   DomainVerificationChallenge,
 } from "../../common/types/api";
@@ -10,9 +11,16 @@ import type {
   UpsertPublicationRecord,
 } from "../../modules/publication/publication.entity";
 
+import { HttpError } from "../../common/errors/http-error";
+
 export const validPublicationBody: AgentPublicationInput = {
   agent_card_url: "https://travel.example.com/.well-known/agent-card.json",
   visibility: "public",
+};
+
+export const testPublisher: PublisherContext = {
+  subject: "publisher:test",
+  isAuthenticated: true,
 };
 
 export const validAgentCard = {
@@ -89,6 +97,38 @@ export class InMemoryPublicationRepository implements PublicationRepository {
     });
   }
 
+  async completeVerification(
+    agentId: string,
+    publisherSubject: string,
+    verifiedAt: string,
+  ): Promise<void> {
+    const record = this.records.get(agentId);
+
+    if (!record) {
+      return;
+    }
+
+    const currentOwner = this.namespaceOwners.get(record.namespace) ?? null;
+
+    if (currentOwner && currentOwner !== publisherSubject) {
+      throw HttpError.forbidden(
+        "publication_forbidden",
+        "The caller does not own this publication record.",
+      );
+    }
+
+    this.namespaceOwners.set(record.namespace, publisherSubject);
+    this.records.set(agentId, {
+      ...record,
+      status: "active",
+      namespaceOwnerSubject: publisherSubject,
+      pendingOwnerSubject: null,
+      challenge: undefined,
+      verifiedAt,
+      lastError: null,
+    });
+  }
+
   async deactivate(agentId: string): Promise<void> {
     const record = this.records.get(agentId);
 
@@ -136,15 +176,32 @@ export const createJsonFetchResponse = (
     ...init,
   });
 
+export const createTextFetchResponse = (
+  payload: string,
+  init: ResponseInit = {},
+): Response =>
+  new Response(payload, {
+    status: 200,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      ...init.headers,
+    },
+    ...init,
+  });
+
 export const createStoredRecord = (
   overrides: Partial<StoredPublicationRecord> = {},
 ): StoredPublicationRecord => {
+  const issuedAt = new Date();
+  const verifiedAt = overrides.verifiedAt;
   const challenge: DomainVerificationChallenge = {
     method: "well_known_token",
     url: "https://travel.example.com/.well-known/agenthub-verification/acme.travel-planner",
     token: "ahv1_testtoken",
-    expires_at: "2026-04-20T12:30:00.000Z",
+    expires_at: new Date(issuedAt.getTime() + 30 * 60_000).toISOString(),
   };
+  const lastValidatedAt =
+    overrides.lastValidatedAt ?? new Date(issuedAt.getTime() - 60_000).toISOString();
 
   return {
     agentId: "acme.travel-planner",
@@ -158,14 +215,14 @@ export const createStoredRecord = (
       source_url: validPublicationBody.agent_card_url,
       access_url: validPublicationBody.agent_card_url,
       access_mode: "public",
-      last_validated_at: "2026-04-20T12:00:00.000Z",
+      last_validated_at: lastValidatedAt,
       etag: "\"etag-1\"",
     },
     namespaceOwnerSubject: null,
     pendingOwnerSubject: "publisher:test",
     challenge,
-    lastValidatedAt: "2026-04-20T12:00:00.000Z",
-    verifiedAt: null,
+    lastValidatedAt,
+    verifiedAt: verifiedAt ?? null,
     lastError: null,
     ...overrides,
   };

--- a/src/tests/integration/routes.integration.test.ts
+++ b/src/tests/integration/routes.integration.test.ts
@@ -5,8 +5,10 @@ import {
   PublicationService,
   type FetchLike,
 } from "../../modules/publication/publication.service";
+import { VerificationService } from "../../modules/verification/verification.service";
 import {
   createJsonFetchResponse,
+  createTextFetchResponse,
   createStoredRecord,
   InMemoryPublicationRepository,
   validAgentCard,
@@ -26,6 +28,11 @@ describe("route validation and publication behavior", () => {
         },
       });
   });
+
+  const buildVerificationApp = (verificationFetch: FetchLike) =>
+    buildApp({
+      verificationService: new VerificationService(repo, verificationFetch),
+    });
 
   it("rejects invalid agent ids", async () => {
     const app = buildApp();
@@ -130,6 +137,215 @@ describe("route validation and publication behavior", () => {
 
     expect(response.status).toBe(400);
     expect(payload.error.code).toBe("invalid_request_body");
+  });
+
+  it("verifies a pending publication and returns active", async () => {
+    repo.seed(createStoredRecord());
+    const app = buildVerificationApp(async () =>
+      createTextFetchResponse(
+        "agent_id=acme.travel-planner\ntoken=ahv1_testtoken\n",
+      ),
+    );
+    const response = await app.handle(
+      new Request(
+        "http://localhost/v1/publish/agents/acme.travel-planner/verify-domain",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "publisher:test",
+          },
+          body: JSON.stringify({ method: "well_known_token" }),
+        },
+      ),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.status).toBe("active");
+    expect(payload.verified_at).toBeString();
+
+    const stored = await repo.getByAgentId("acme.travel-planner");
+    expect(stored?.status).toBe("active");
+    expect(stored?.challenge).toBeUndefined();
+    expect(stored?.namespaceOwnerSubject).toBe("publisher:test");
+  });
+
+  it("rejects expired verification challenges", async () => {
+    repo.seed(
+      createStoredRecord({
+        challenge: {
+          method: "well_known_token",
+          url: "https://travel.example.com/.well-known/agenthub-verification/acme.travel-planner",
+          token: "ahv1_testtoken",
+          expires_at: new Date(Date.now() - 60_000).toISOString(),
+        },
+      }),
+    );
+    const app = buildVerificationApp(async () =>
+      createTextFetchResponse("unexpected"),
+    );
+    const response = await app.handle(
+      new Request(
+        "http://localhost/v1/publish/agents/acme.travel-planner/verify-domain",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "publisher:test",
+          },
+          body: JSON.stringify({ method: "well_known_token" }),
+        },
+      ),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(payload.error.code).toBe("verification_challenge_expired");
+  });
+
+  it("rejects wrong verification bodies", async () => {
+    repo.seed(createStoredRecord());
+    const app = buildVerificationApp(async () =>
+      createTextFetchResponse("agent_id=acme.travel-planner\ntoken=wrong"),
+    );
+    const response = await app.handle(
+      new Request(
+        "http://localhost/v1/publish/agents/acme.travel-planner/verify-domain",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "publisher:test",
+          },
+          body: JSON.stringify({ method: "well_known_token" }),
+        },
+      ),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(payload.error.code).toBe("domain_verification_failed");
+  });
+
+  it("rejects missing verification files", async () => {
+    repo.seed(createStoredRecord());
+    const app = buildVerificationApp(
+      async () => new Response("not found", { status: 404 }),
+    );
+    const response = await app.handle(
+      new Request(
+        "http://localhost/v1/publish/agents/acme.travel-planner/verify-domain",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "publisher:test",
+          },
+          body: JSON.stringify({ method: "well_known_token" }),
+        },
+      ),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(payload.error.code).toBe("domain_verification_failed");
+  });
+
+  it("rejects redirects to a different origin", async () => {
+    repo.seed(createStoredRecord());
+    const app = buildVerificationApp(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: {
+            location:
+              "https://other.example.com/.well-known/agenthub-verification/acme.travel-planner",
+          },
+        }),
+    );
+    const response = await app.handle(
+      new Request(
+        "http://localhost/v1/publish/agents/acme.travel-planner/verify-domain",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "publisher:test",
+          },
+          body: JSON.stringify({ method: "well_known_token" }),
+        },
+      ),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(payload.error.code).toBe("domain_verification_failed");
+  });
+
+  it("rejects verify attempts from a different subject after namespace ownership is bound", async () => {
+    repo.seed(
+      createStoredRecord({
+        namespaceOwnerSubject: "publisher:claimed-owner",
+        pendingOwnerSubject: null,
+      }),
+    );
+    const app = buildVerificationApp(async () =>
+      createTextFetchResponse(
+        "agent_id=acme.travel-planner\ntoken=ahv1_testtoken",
+      ),
+    );
+    const response = await app.handle(
+      new Request(
+        "http://localhost/v1/publish/agents/acme.travel-planner/verify-domain",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "publisher:test",
+          },
+          body: JSON.stringify({ method: "well_known_token" }),
+        },
+      ),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(payload.error.code).toBe("publication_forbidden");
+  });
+
+  it("rejects already-active records as ineligible for verification", async () => {
+    repo.seed(
+      createStoredRecord({
+        status: "active",
+        challenge: undefined,
+        namespaceOwnerSubject: "publisher:test",
+        pendingOwnerSubject: null,
+        verifiedAt: new Date().toISOString(),
+      }),
+    );
+    const app = buildVerificationApp(async () =>
+      createTextFetchResponse(
+        "agent_id=acme.travel-planner\ntoken=ahv1_testtoken",
+      ),
+    );
+    const response = await app.handle(
+      new Request(
+        "http://localhost/v1/publish/agents/acme.travel-planner/verify-domain",
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: "publisher:test",
+          },
+          body: JSON.stringify({ method: "well_known_token" }),
+        },
+      ),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(payload.error.code).toBe("verification_challenge_expired");
   });
 
   it("publishes a valid agent and returns pending_verification", async () => {

--- a/src/tests/unit/dummy-agent-card.unit.test.ts
+++ b/src/tests/unit/dummy-agent-card.unit.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  buildVerificationBody,
+  createDummyAgentCardFetchHandler,
+  dummyVerificationAdminPath,
+  dummyVerificationPathPrefix,
+} from "../../../scripts/lib/dummy-agent-card-server";
+
+describe("dummy agent card server handler", () => {
+  const baseUrl = "https://localhost:8443";
+  const handler = createDummyAgentCardFetchHandler({
+    baseUrl,
+    cardUrl: `${baseUrl}/.well-known/agent-card.json`,
+  });
+
+  it("serves the dummy agent card", async () => {
+    const response = await handler(
+      new Request(`${baseUrl}/.well-known/agent-card.json`),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.name).toBe("Local Dummy Agent");
+  });
+
+  it("configures and serves verification bodies", async () => {
+    const configureResponse = await handler(
+      new Request(`${baseUrl}${dummyVerificationAdminPath}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          agent_id: "acme.travel-planner",
+          token: "ahv1_testtoken",
+        }),
+      }),
+    );
+
+    expect(configureResponse.status).toBe(200);
+
+    const verificationResponse = await handler(
+      new Request(
+        `${baseUrl}${dummyVerificationPathPrefix}acme.travel-planner`,
+      ),
+    );
+
+    expect(verificationResponse.status).toBe(200);
+    expect(await verificationResponse.text()).toBe(
+      buildVerificationBody("acme.travel-planner", "ahv1_testtoken"),
+    );
+  });
+
+  it("rejects invalid verification configuration payloads", async () => {
+    const response = await handler(
+      new Request(`${baseUrl}${dummyVerificationAdminPath}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          agent_id: "",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/tests/unit/services.unit.test.ts
+++ b/src/tests/unit/services.unit.test.ts
@@ -7,19 +7,16 @@ import {
 } from "../../modules/publication/publication.service";
 import { VerificationService } from "../../modules/verification/verification.service";
 import { DiscoveryService } from "../../modules/discovery/discovery.service";
-import type { PublisherContext, SearchEnvelope, VerifyDomainRequest } from "../../common/types/api";
+import type { SearchEnvelope, VerifyDomainRequest } from "../../common/types/api";
 import {
   createJsonFetchResponse,
+  createTextFetchResponse,
   createStoredRecord,
   InMemoryPublicationRepository,
+  testPublisher,
   validAgentCard,
   validPublicationBody,
 } from "../helpers/publication-test-helpers";
-
-const publisher: PublisherContext = {
-  subject: "publisher:test",
-  isAuthenticated: true,
-};
 
 const verifyPayload: VerifyDomainRequest = {
   method: "well_known_token",
@@ -46,7 +43,7 @@ describe("publication service", () => {
     const result = await service.publishAgent(
       "acme.travel-planner",
       validPublicationBody,
-      publisher,
+      testPublisher,
     );
 
     expect(result.created).toBe(true);
@@ -72,7 +69,7 @@ describe("publication service", () => {
     const service = new PublicationService(repo, fetchStub);
 
     await expect(
-      service.getPublication("acme.travel-planner", publisher),
+      service.getPublication("acme.travel-planner", testPublisher),
     ).rejects.toMatchObject({
       code: "publication_forbidden",
       status: 403,
@@ -100,8 +97,7 @@ describe("publication service", () => {
     });
   });
 
-  it("keeps verification and discovery services as typed placeholders", async () => {
-    const verificationService = new VerificationService();
+  it("keeps discovery service as a typed placeholder", async () => {
     const discoveryService = new DiscoveryService({
       async getByAgentId() {
         return null;
@@ -114,30 +110,164 @@ describe("publication service", () => {
       },
     });
 
-    await expect(
-      verificationService.verifyDomain(
-        "acme.travel-planner",
-        verifyPayload,
-        publisher,
-      ),
-    ).rejects.toBeInstanceOf(HttpError);
-
     await expect(discoveryService.searchAgents(searchPayload)).rejects.toBeInstanceOf(
       HttpError,
     );
   });
 });
 
-describe("remaining service placeholders", () => {
-  it("verification service throws a typed 501", async () => {
-    const service = new VerificationService();
+describe("verification service", () => {
+  let repo: InMemoryPublicationRepository;
 
-    await expect(
-      service.verifyDomain("acme.travel-planner", verifyPayload, publisher),
-    ).rejects.toBeInstanceOf(HttpError);
+  beforeEach(() => {
+    repo = new InMemoryPublicationRepository();
   });
 
-  it("discovery service throws a typed 501", async () => {
+  it("activates a pending record after exact same-origin proof and claims the namespace", async () => {
+    repo.seed(createStoredRecord());
+    const service = new VerificationService(
+      repo,
+      async () =>
+        createTextFetchResponse(
+          "agent_id=acme.travel-planner\ntoken=ahv1_testtoken",
+        ),
+    );
+
+    const result = await service.verifyDomain(
+      "acme.travel-planner",
+      verifyPayload,
+      testPublisher,
+    );
+
+    expect(result.status).toBe("active");
+    expect(result.verified_at).toBeString();
+
+    const stored = await repo.getByAgentId("acme.travel-planner");
+    expect(stored?.status).toBe("active");
+    expect(stored?.namespaceOwnerSubject).toBe("publisher:test");
+    expect(stored?.pendingOwnerSubject).toBeNull();
+    expect(stored?.challenge).toBeUndefined();
+    expect(stored?.verifiedAt).toBeString();
+  });
+
+  it("rejects expired challenges", async () => {
+    repo.seed(
+      createStoredRecord({
+        challenge: {
+          method: "well_known_token",
+          url: "https://travel.example.com/.well-known/agenthub-verification/acme.travel-planner",
+          token: "ahv1_testtoken",
+          expires_at: new Date(Date.now() - 60_000).toISOString(),
+        },
+      }),
+    );
+    const service = new VerificationService(repo, async () =>
+      createTextFetchResponse("unexpected"),
+    );
+
+    await expect(
+      service.verifyDomain(
+        "acme.travel-planner",
+        verifyPayload,
+        testPublisher,
+      ),
+    ).rejects.toMatchObject({
+      code: "verification_challenge_expired",
+      status: 409,
+    });
+  });
+
+  it("rejects wrong verification bodies", async () => {
+    repo.seed(createStoredRecord());
+    const service = new VerificationService(repo, async () =>
+      createTextFetchResponse("agent_id=acme.travel-planner\ntoken=wrong"),
+    );
+
+    await expect(
+      service.verifyDomain(
+        "acme.travel-planner",
+        verifyPayload,
+        testPublisher,
+      ),
+    ).rejects.toMatchObject({
+      code: "domain_verification_failed",
+      status: 403,
+    });
+  });
+
+  it("rejects missing verification files", async () => {
+    repo.seed(createStoredRecord());
+    const service = new VerificationService(
+      repo,
+      async () => new Response("not found", { status: 404 }),
+    );
+
+    await expect(
+      service.verifyDomain(
+        "acme.travel-planner",
+        verifyPayload,
+        testPublisher,
+      ),
+    ).rejects.toMatchObject({
+      code: "domain_verification_failed",
+      status: 403,
+    });
+  });
+
+  it("rejects redirects that change origin", async () => {
+    repo.seed(createStoredRecord());
+    const service = new VerificationService(
+      repo,
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: {
+            location:
+              "https://other.example.com/.well-known/agenthub-verification/acme.travel-planner",
+          },
+        }),
+    );
+
+    await expect(
+      service.verifyDomain(
+        "acme.travel-planner",
+        verifyPayload,
+        testPublisher,
+      ),
+    ).rejects.toMatchObject({
+      code: "domain_verification_failed",
+      status: 403,
+    });
+  });
+
+  it("rejects later verification attempts by a different subject", async () => {
+    repo.seed(
+      createStoredRecord({
+        namespaceOwnerSubject: "publisher:claimed-owner",
+        pendingOwnerSubject: null,
+      }),
+    );
+    const service = new VerificationService(
+      repo,
+      async () =>
+        createTextFetchResponse(
+          "agent_id=acme.travel-planner\ntoken=ahv1_testtoken",
+        ),
+    );
+
+    await expect(
+      service.verifyDomain(
+        "acme.travel-planner",
+        verifyPayload,
+        testPublisher,
+      ),
+    ).rejects.toMatchObject({
+      code: "publication_forbidden",
+      status: 403,
+    });
+  });
+
+  it("keeps discovery service as a typed placeholder", async () => {
     const service = new DiscoveryService({
       async getByAgentId() {
         return null;


### PR DESCRIPTION
## Summary
Implement the spec-aligned `POST /v1/publish/agents/{agent_id}/verify-domain` flow, including stored challenge validation, namespace claiming, activation, and local testing support.

## Key Changes
- Added real verification service logic for owner checks, challenge expiry, same-origin HTTPS proof fetching, redirect validation, and exact body matching in `src/modules/verification/verification.service.ts:21`.
- Added the atomic verification completion transition that claims unowned namespaces, marks publications `active`, sets `verifiedAt`, and clears outstanding challenges in `src/modules/publication/publication.repo.ts:248`.
- Wired the app to use the real verification service instead of the placeholder path and removed the verification `501` route contract in `src/app.ts:74`, `src/modules/verification/verification.plugin.ts:6`, and `src/modules/verification/verification.route.ts:24`.
- Added regression coverage for verification success, expiry, body mismatch, missing file, redirect rejection, and owner enforcement in `src/tests/unit/services.unit.test.ts:119` and `src/tests/integration/routes.integration.test.ts:139`.
- Added a maintainer-oriented verification guide and tightened the manual runbook for local happy-path testing in `docs/domain-verification-workflow.md:1` and `docs/manual-testing.md:11`.
- Added local dummy-server support for `/.well-known/agenthub-verification/{agent_id}` plus an admin endpoint to load challenge tokens for end-to-end local verification testing in `scripts/lib/dummy-agent-card-server.ts:56` and `src/tests/unit/dummy-agent-card.unit.test.ts:10`.
- Added `bun run db:studio` so maintainers can inspect the local database during verification debugging in `package.json:4`.

## Validation
- `bun test`
- `bun run docs:openapi:check`
- `bun run db:studio --help`

Closes #6
